### PR TITLE
Bug #7243

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -300,6 +300,12 @@ var Expr = Sizzle.selectors = {
 		CLASS: /\.((?:[\w\u00c0-\uFFFF\-]|\\.)+)/,
 		NAME: /\[name=['"]*((?:[\w\u00c0-\uFFFF\-]|\\.)+)['"]*\]/,
 		ATTR: /\[\s*((?:[\w\u00c0-\uFFFF\-]|\\.)+)\s*(?:(\S?=)\s*(['"]*)(.*?)\3|)\s*\]/,
+		// This expression is only necessary to detect != attribute
+		// selectors separately from other attribute selectors, as != is not a
+		// real CSS3 operator, and matchesSelector in Firefox fails to throw
+		// errors for invalid CSS strings, so we need to detect it ourselves.
+		// Fixes jQuery bug #7243.
+		ATTR_NOT_EQUAL: /\[\s*(?:[\w\u00c0-\uFFFF\-]|\\.)+\s*(?:!=\s*(['"]*).*?\1|)\s*\]/,
 		TAG: /^((?:[\w\u00c0-\uFFFF\*\-]|\\.)+)/,
 		CHILD: /:(only|nth|last|first)-child(?:\((even|odd|[\dn+\-]*)\))?/,
 		POS: /:(nth|eq|gt|lt|first|last|even|odd)(?:\((\d*)\))?(?=[^\-]|$)/,
@@ -1008,7 +1014,7 @@ if ( document.querySelectorAll ) {
 	if ( matches ) {
 		Sizzle.matchesSelector = function( node, expr ) {
 				try { 
-					if ( pseudoWorks || !Expr.match.PSEUDO.test( expr ) ) {
+					if ( pseudoWorks || (!Expr.match.PSEUDO.test( expr ) && !Expr.match.ATTR_NOT_EQUAL.test( expr )) ) {
 						return matches.call( node, expr );
 					}
 				} catch(e) {}


### PR DESCRIPTION
This is a potential fix for bug [#7243](http://bugs.jquery.com/ticket/7243). If it looks reasonable, I will add some test cases to this pull request as well before it lands.

At the least, I’m not sure that the expression needs to actually look for an entire well-formed selector; I would imagine it could stop safely after the `!=`, given what it is being used for, and that would probably save some time. There may also be another even smarter way to do this that I completely overlooked—for instance, the cost of running the regular expression might outweigh the performance benefit of native matchesSelector, and a simple .indexOf('!=') might be smarter in that scenario. I’ll try running some jsperf tests to figure it out.
