### PR TITLE
Fix jslint failure from aa6076c6a2b79acd2f8c

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1083,7 +1083,7 @@ if ( document.querySelectorAll ) {
 			context = context || document;
 
 			// Make sure that attribute selectors are quoted
-			query = query.replace(/=\s*([^'"\]]*)\s*\]/g, "='$1']");
+			query = query.replace(/\=\s*([^'"\]]*)\s*\]/g, "='$1']");
 
 			// Only use querySelectorAll on non-XML documents
 			// (ID selectors don't work in non-HTML documents)
@@ -1146,7 +1146,7 @@ if ( document.querySelectorAll ) {
 	if ( matches ) {
 		Sizzle.matchesSelector = function( node, expr ) {
 			// Make sure that attribute selectors are quoted
-			expr = expr.replace(/=\s*([^'"\]]*)\s*\]/g, "='$1']");
+			expr = expr.replace(/\=\s*([^'"\]]*)\s*\]/g, "='$1']");
 
 			if ( !Sizzle.isXML( node ) ) {
 				try { 


### PR DESCRIPTION
jslint complains about this regular expression. I get the feeling this is actually a bug in jslint since I don’t believe that an equal sign at the beginning of an expression denotes any sort of special magic, but…here’s a fix to get the build system working again anyway.

```
Checking jQuery against JSLint...

            expr = expr.replace(/=\s*([^'"\]]*)\s*\]/g, "='$1']");

 Problem at line 4148 character 35: Unexpected '\'.

undefined

Problem at line 4148 character 35: Stopping, unable to continue. (57% scanned).
js: uncaught JavaScript runtime exception: TypeError: Cannot read property "reason" from null
make: *** [lint] Error 3
```
