### PR TITLE
Faster :even and :odd

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -646,11 +646,11 @@ var Expr = Sizzle.selectors = {
 		},
 
 		even: function( elem, i ) {
-			return i % 2 === 0;
+			return (i & 1) === 0;
 		},
 
 		odd: function( elem, i ) {
-			return i % 2 === 1;
+			return (i & 1) === 1;
 		},
 
 		lt: function( elem, i, match ) {


### PR DESCRIPTION
Between 27% and 248% faster according to [this jsPerf test](http://jsperf.com/modulo-vs-bitwise/7). Originally suggested at jQuery ticket [#5898](http://bugs.jquery.com/ticket/5898).
