### PR TITLE
Fixes #7452. Fixes regression for Element-rooted hierarchy-selector-queries

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1108,14 +1108,19 @@ if ( document.querySelectorAll ) {
 				// IE 8 doesn't work on object elements
 				} else if ( context.nodeType === 1 && context.nodeName.toLowerCase() !== "object" ) {
 					var old = context.getAttribute( "id" ),
-						nid = old || id;
+						nid = old || id,
+						hasParent = context.parentNode,
+						relativeHierarchySelector = /^\s*[+~]/.test( query );
 
 					if ( !old ) {
 						context.setAttribute( "id", nid );
 					}
+					if ( relativeHierarchySelector && hasParent ) {
+						context = context.parentNode;
+					}
 
 					try {
-						if ( !/^\s*[+~]/.test( query ) ) {
+						if ( !relativeHierarchySelector || hasParent ) {
 							return makeArray( context.querySelectorAll( "#" + nid + " " + query ), extra );
 						}
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -213,7 +213,7 @@ test("multiple", function() {
 });
 
 test("child and adjacent", function() {
-	expect(29);
+	expect(31);
 	t( "Child", "p > a", ["simon1","google","groups","mark","yahoo","simon"] );
 	t( "Child", "p> a", ["simon1","google","groups","mark","yahoo","simon"] );
 	t( "Child", "p >a", ["simon1","google","groups","mark","yahoo","simon"] );
@@ -237,6 +237,9 @@ test("child and adjacent", function() {
 	t( "Element Preceded By", "#siblingfirst ~ em", ["siblingnext"] );
 	same( jQuery("#siblingfirst").find("~ em").get(), q("siblingnext"), "Element Preceded By with a context." );
 	same( jQuery("#siblingfirst").find("+ em").get(), q("siblingnext"), "Element Directly Preceded By with a context." );
+	var a = jQuery("<div id='foo'></div><p id='bar'></p><p id='bar2'></p>");
+	same( jQuery("~ p", a[0]).get(), [a[1], a[2]], "Detached Element Directly Preceded By with a context." );
+	same( jQuery("+ p", a[0]).get(), [a[1]], "Detached Element Preceded By with a context." );
 
 	t( "Verify deep class selector", "div.blah > p > a", [] );
 


### PR DESCRIPTION
Fixes the regression descried in [#7452](http://bugs.jquery.com/ticket/7452). e.g.

```
$("#id").find("~ div")
```

The fix is only needed for the `~` and `+` selector.

You might decide to just cherry-pick the first commit if the optimization to allow qSA most of the time is to convoluted. The first commit just delegates this special case to `oldSizzle`
