### PR TITLE
Bug #7533. Fix for Element-rooted queries where ID contains CSS3 selector meta characters

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1112,10 +1112,12 @@ if ( document.querySelectorAll ) {
 
 					if ( !old ) {
 						context.setAttribute( "id", nid );
+					} else {
+						nid = nid.replace( /'/g, "\\$&" );
 					}
 
 					try {
-						return makeArray( context.querySelectorAll( "#" + nid + " " + query ), extra );
+						return makeArray( context.querySelectorAll( "[id='" + nid + "'] " + query ), extra );
 
 					} catch(pseudoError) {
 					} finally {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -91,7 +91,7 @@ test("broken", function() {
 });
 
 test("id", function() {
-	expect(28);
+	expect(29);
 	t( "ID Selector", "#body", ["body"] );
 	t( "ID Selector w/ Element", "body#body", ["body"] );
 	t( "ID Selector w/ Element", "ul#first", [] );
@@ -126,6 +126,9 @@ test("id", function() {
 	t( "ID selector with non-existant ancestor", "#asdfasdf #foobar", [] ); // bug #986
 
 	same( jQuery("body").find("div#form").get(), [], "ID selector within the context of another element" );
+
+	//#7533
+	equal( jQuery("<div id=\"A'B~C.D[E]\"><p>foo</p></div>").find("p").length, 1, "Find where context root is a node and has an ID with CSS3 meta characters" );
 
 	t( "Underscore ID", "#types_all", ["types_all"] );
 	t( "Dash ID", "#fx-queue", ["fx-queue"] );


### PR DESCRIPTION
This fixes bug [#7533](http://bugs.jquery.com/ticket/7533) for Element-rooted queries where the root has an ID which contains CSS 3 selector meta characters. Previously we didn't escape them and thus got "wrong" results from qSA as it interpreted the ID as CSS3 selector. Solution credits go to John Resig

Also check the discussion/commits on the pull request with the [first fix attempt](https://github.com/jeresig/sizzle/pull/37) for this bug for further info.
