### PR TITLE
Fix escaped attribute names/values for non qSA browsers

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -531,14 +531,14 @@ var Expr = Sizzle.selectors = {
 		},
 
 		ATTR: function( match, curLoop, inplace, result, not, isXML ) {
-			var name = match[1].replace(/\\/g, "");
+			var name = match[1] = match[1].replace(/\\/g, "");
 			
 			if ( !isXML && Expr.attrMap[name] ) {
 				match[1] = Expr.attrMap[name];
 			}
 
 			// Handle if an un-quoted value was used
-			match[4] = match[4] || match[5] || "";
+			match[4] = ( match[4] || match[5] || "" ).replace(/\\/g, "");
 
 			if ( match[2] === "~=" ) {
 				match[4] = " " + match[4] + " ";

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -264,7 +264,7 @@ test("child and adjacent", function() {
 });
 
 test("attributes", function() {
-	expect(41);
+	expect(43);
 
 	t( "Attribute Exists", "a[title]", ["google"] );
 	t( "Attribute Exists", "*[title]", ["google"] );
@@ -330,6 +330,15 @@ test("attributes", function() {
 	t("Find escaped attribute value", "input[name=foo\\[baz\\]]", ["attrbad2"]);
 
 	attrbad.remove();
+
+	//#6428
+	t("Find escaped attribute value", "#form input[name=foo\\[bar\\]]", ["hidden2"]);
+
+	//#3279
+	var div = document.createElement("div");
+	div.innerHTML = "<div id='foo' xml:test='something'></div>";
+	
+	deepEqual( jQuery( "[xml\\:test]", div ).get(), [ div.firstChild ], "Finding by attribute with escaped characters." );
 });
 
 test("pseudo - child", function() {


### PR DESCRIPTION
http://bugs.jquery.com/ticket/3729

http://bugs.jquery.com/ticket/6428
