### PR TITLE
Fixes jQuery bug #8539

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -7,7 +7,7 @@
 (function(){
 
 var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[^\[\]'"]+)+\]|\\.|[^ >+~,(\[\\]+)+|[>+~])(\s*,\s*)?((?:.|\r|\n)*)/g,
-	done = 0,
+	done = Math.random(),
 	toString = Object.prototype.toString,
 	hasDuplicate = false,
 	baseHasDuplicate = true,


### PR DESCRIPTION
From [bug 8539](http://bugs.jquery.com/ticket/8539) (Sizzle cache collision in browsers without querySelectorAll):

> In browsers without querySelectorAll (IE 6, IE 7, FF 3.0), Sizzle marks the elements it encounters as seen for a particular selection run. The value used as a marker is an integer that comes from an internal counter which is incremented before each new selection, and these markers on left on the elements after selection completes.
> 
> This causes trouble when there are two copies of Sizzle on the page. Running a selection in Sizzle copy A sets the marker on a set of elements to 0. If you then run a selection in Sizzle copy B that passes through the same elements, Sizzle will assume it is safe to use a cached value at that point, since the stored marker of 0 matches copy B's marker for this run. This gives unexpected selection results.
> 
> See http://jsfiddle.net/uz4dt/6/ for a test case. The second test fails for browsers without querySelectorAll.
