### PR TITLE
Switch option creation to createElement due to a bug in Opera

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -550,7 +550,7 @@ test("pseudo - form", function() {
 
 test("disconnected nodes", function() {
 	expect(4);
-	var $opt = jQuery( '<option value="whipit">Whip It</option>' ).appendTo("#main").detach();
+	var $opt = jQuery('<option></option>').attr("value", "whipit").appendTo("#main").detach();
 	equal( $opt.val(), "whipit", "option value" );
 	equal( $opt.is(":selected"), false, "unselected option" );
 	$opt.attr("selected", true);


### PR DESCRIPTION
- Switch option creation to createElement due to a bug in Opera with setting selected on fragments made by jQuery.
- I've spent hours tracking this bug down.  Setting 'selected' to true does not change the property on an option that was created using a fragment and then merged with an instance of jQuery.  It's a very tedious Opera bug that I concluded would take up too much code in jQuery to fix.  If I'm right, it would mean another test in support.js (on document ready no less) and at least 9 lines of code in attributes.js applying a separate hook for the selected attribute.  It is not, however, a bug in attributes.js, but more likely a bug in manipulation.js (actually in Opera) and adding a hook would just be covering up the real problem.  Regardless, I'll add a jQuery ticket, but for now sizzle can have clear tests with 1.6 with this change.
