### PR TITLE
Bug 6863; Use array.join() for string concatenation in getText()

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -995,18 +995,21 @@ if ( document.documentElement.compareDocumentPosition ) {
 
 // Utility function for retreiving the text value of an array of DOM nodes
 Sizzle.getText = function( elems ) {
-	var ret = "", elem;
+	var nodeType = elems.nodeType,
+		ret = "";
 
-	for ( var i = 0; elems[i]; i++ ) {
-		elem = elems[i];
-
-		// Get the text from text nodes and CDATA nodes
-		if ( elem.nodeType === 3 || elem.nodeType === 4 ) {
-			ret += elem.nodeValue;
-
-		// Traverse everything else, except comment nodes
-		} else if ( elem.nodeType !== 8 ) {
-			ret += Sizzle.getText( elem.childNodes );
+	// Get text from the array elements if this is not a node
+	if ( nodeType == null ) {
+		for ( var i = 0; elems[i]; i++ ) {
+			ret += Sizzle.getText( elems[i] );
+		}
+	// Get the text from text nodes and CDATA nodes
+	} else if ( nodeType === 3 || nodeType === 4 ) {
+		ret += elems.nodeValue;
+	// Traverse everything else, except comment nodes
+	} else if ( nodeType !== 8 ) {
+		for ( var node = elems.firstChild; node; node = node.nextSibling) {
+			ret += Sizzle.getText( node );
 		}
 	}
 


### PR DESCRIPTION
This fixes [jQuery bug #6863: Faster getText](http://bugs.jquery.com/ticket/6863) by using Array.join('') instead of += for string concatenation.

Based on comparisons of [Array.join vs string concatenation on jsPerf](http://jsperf.com/ultimate-string-concatenation-tests) this change may have a negative impact on performance in Chrome, Firefox 4 and IE8+. It will have a minor performance benefit in IE6 and IE7, Safari (as of version 5.0.5) and Opera (as of 11.10).
