### PR TITLE
Tweak for isXML

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1377,11 +1377,8 @@ if ( document.documentElement.contains ) {
 }
 
 Sizzle.isXML = function( elem ) {
-	// documentElement is verified for cases where it doesn't yet exist
-	// (such as loading iframes in IE - #4833) 
-	var documentElement = (elem ? elem.ownerDocument || elem : 0).documentElement;
-
-	return documentElement ? documentElement.nodeName !== "HTML" : false;
+	var doc = elem.ownerDocument || elem;
+	return !!doc.xmlVersion || !!doc.xml; // .xml is for IE
 };
 
 var posProcess = function( selector, context ) {


### PR DESCRIPTION
Updated isXML to more reliably test for XMLDocument by targeting properties only available on XMLDocument. It would be nice if we could just test for `elem instanceof XMLDocument`, but xhr returns [`Document` from xhr.recieveXML](http://www.w3.org/TR/XMLHttpRequest/#document-response-entity-body). Thankfully all browsers add the XMLDocument properties anyway (specifically xmlVersion or xml [in ie]).

This passes all tests for sizzle and jquery. It resolves the need for the check added for bug 4833. I didn't see a reason to add any more tests. Let me know if you find anything wrong.
