### PR TITLE
Fix for #10584: better error text in IE on sizzle syntax errors

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -325,7 +325,7 @@ Sizzle.filter = function( expr, set, inplace, not ) {
 };
 
 Sizzle.error = function( msg ) {
-	throw "Syntax error, unrecognized expression: " + msg;
+	throw new Error("Syntax error, unrecognized expression: " + msg);
 };
 
 /**

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -66,7 +66,7 @@ test("broken", function() {
 			jQuery(selector);
 			ok( false, name + ": " + selector );
 		} catch(e){
-			ok( typeof e === "string" && e.indexOf("Syntax error") >= 0,
+			ok( e instanceof Error && e.message.indexOf("Syntax error") >= 0,
 				name + ": " + selector );
 		}
 	}


### PR DESCRIPTION
[Bug #10584](http://bugs.jquery.com/ticket/10584)

As [Nicholas Zakas explains](http://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/), old versions of IE and Safari show less-than-meaningful messages ("Exception thrown and not caught on line X") when strings are thrown instead of instances of the Error object. This commit addresses this issue.
