### PR TITLE
Fixes IE7 domain violation on Expr.attrHandle.type

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -392,8 +392,9 @@ var Expr = Sizzle.selectors = {
 		href: function( elem ) {
 			return elem.getAttribute( "href" );
 		},
+		// Only IE7 calls this on all nodes.  Conditional prevents domain violation on IFRAME.
 		type: function( elem ) {
-			return elem.getAttribute( "type" );
+			if (elem.tagName !== "IFRAME") return elem.getAttribute( "type" );
 		}
 	},
 


### PR DESCRIPTION
Expr.attrHandle.type gets called on every node in IE7, which is harmless until it reaches an iframe then, BAM!

Domain violation, access denied.
