### PR TITLE
Made getText() work for DocumentFragment

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -338,7 +338,7 @@ var getText = Sizzle.getText = function( elem ) {
 		ret = "";
 
 	if ( nodeType ) {
-		if ( nodeType === 1 || nodeType === 9 ) {
+		if ( nodeType === 1 || nodeType === 9 || nodeType === 11 ) {
 			// Use textContent || innerText for elements
 			if ( typeof elem.textContent === 'string' ) {
 				return elem.textContent;


### PR DESCRIPTION
In version 1.7 of jQuery .text() no longer work for document fragments.
This commit fixes that.
