### PR TITLE
Fix 'Operation not supported' on Firefox and 'No such interface supported' on IE

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1394,12 +1394,20 @@ function dirCheck( dir, cur, doneName, checkSet, nodeCheck, isXML ) {
 
 if ( document.documentElement.contains ) {
 	Sizzle.contains = function( a, b ) {
-		return a !== b && (a.contains ? a.contains(b) : true);
+		try {
+			return a !== b && (a.contains ? a.contains(b) : true);
+		} catch (e) {
+			return false;
+		}
 	};
 
 } else if ( document.documentElement.compareDocumentPosition ) {
 	Sizzle.contains = function( a, b ) {
-		return !!(a.compareDocumentPosition(b) & 16);
+		try {
+			return !!(a.compareDocumentPosition(b) & 16);
+		} catch (e) {
+			return false;
+		}
 	};
 
 } else {


### PR DESCRIPTION
At my work some days ago I need to be compatible the same view on Firefox 3.5 and Internet Explorer 8 after update to jquery 1.7.1 can observe an error on Firefox with the message: 'Operation not supported' and I discover on the internet a solution to this error, put the line:

``` javascript
Sizzle.contains = function(a, b) {
      return !!(a.compareDocumentPosition(b) & 16);
}
```

Inside a try catch and if throw an exception the method returning false. The same behavior occur with the implementation that IE 8 call some lines before:

``` javascript
Sizzle.contains = function( a, b ) {
    return a !== b && (a.contains ? a.contains(b) : true);
};
```

And the same solution was resolved to me!
