### PR TITLE
Minimize makeArray

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -912,14 +912,8 @@ for ( var type in Expr.match ) {
 Expr.match.globalPOS = origPOS;
 
 var makeArray = function( array, results ) {
-	array = Array.prototype.slice.call( array, 0 );
-
-	if ( results ) {
-		results.push.apply( results, array );
-		return results;
-	}
-
-	return array;
+	array = [].slice.call( array );
+	return results ? results = [].push.apply( results, array ) : array;
 };
 
 // Perform a simple check to determine if the browser is capable of


### PR DESCRIPTION
```
jQuery Size - compared to last make
  252723    (-43) jquery.js
   94798    (-25) jquery.min.js
   33637     (-6) jquery.min.js.gz
```

Testsuite passes in Chrome, Firefox 11/3.6, Safari 5, Opera 11, IE6-9.
[jsperf](http://jsperf.com/bbarr-new-array-vs-literal/3)
