### PR TITLE
fix the bug of Sizzle('div .a, div .b',Sizzle('#div1'))

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1218,7 +1218,7 @@ if ( document.querySelectorAll ) {
 
 					try {
 						if ( !relativeHierarchySelector || hasParent ) {
-							return makeArray( context.querySelectorAll( "[id='" + nid + "'] " + query ), extra );
+							return makeArray( context.querySelectorAll( "[id='" + nid + "'] " + query.replace(/\,/g,",[id='" + nid + "'] ") ), extra );
 						}
 
 					} catch(pseudoError) {


### PR DESCRIPTION
bug description:

html code:
&lt;div id="div1"&gt;
    &lt;span class="a"&gt;a1&lt;/span&gt;
    &lt;span class="b"&gt;b1&lt;/span&gt;
    &lt;div id="div2"&gt;
        &lt;span class="a"&gt;a2&lt;/span&gt;
        &lt;span class="b"&gt;b2&lt;/span&gt;
    &lt;/div>
&lt;/div>

js code:
Sizzle('div .a, div .b',Sizzle('#div1'))

expected result is a2, b2:
     [&lt;span class="a"&gt;a2&lt;/span&gt;,&lt;span class="b"&gt;b2&lt;/span&gt;]
actual result is b1,a2, b2:
     [&lt;span class="b"&gt;b1&lt;/span&gt;,&lt;span class="a"&gt;a2&lt;/span&gt;,&lt;span class="b"&gt;b2&lt;/span&gt;]
