### PR TITLE
perf

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1063,16 +1063,12 @@ function addCombinator( matcher, combinator, context ) {
 		while ( (elem = elem[ dir ]) ) {
 			if ( elem.nodeType === 1 ) {
 				if ( elem[ expando ] === cachedkey ) {
-					if ( elem.sizset ) {
-						return elem;
-					}
+					return false;
 				} else {
 					elem[ expando ] = cachedkey;
 					if ( matcher( elem, context ) ) {
-						elem.sizset = true;
 						return elem;
 					}
-					elem.sizset = false;
 				}
 				if ( firstMatch ) {
 					break;
@@ -1228,6 +1224,7 @@ var select = function( selector, context, results, seed, xml ) {
 				if ( matcher(elem, context) ) {
 					results.push( elem );
 				}
+				cachedruns = ++matcher.runs;
 			}
 		}
 	}


### PR DESCRIPTION
```
var div = document.createElement('div');
var wrongSelector = '.null>u u u u code';
var s = '<i><b>' + Array(40).join('<u>') + Array(128).join('<p></p>') + '<code>123</code>' + Array(40).join('</u>') + '</b></i>';
div.innerHTML = s;
var code = div.querySelector('code');
```

   jQuery.find.matchesSelector(code, wrongSelector);

this change should improve worst cases for jquery from this test:
http://jsperf.com/nwmatches-vs-modified-nwmatcher/12
