### PR TITLE
Preserve original context when qsA fails

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -60,7 +60,7 @@ var cachedruns,
 	// Easily-parseable/retrievable ID or TAG or CLASS selectors
 	rquickExpr = /^(?:#([\w\-]+)|(\w+)|\.([\w\-]+))$/,
 
-	rsibling = /^[\x20\t\r\n\f]*[+~]/,
+	rsibling = /[\x20\t\r\n\f]*[+~]/,
 	rendsWithNot = /:not\($/,
 
 	rheader = /h\d/i,
@@ -1250,7 +1250,7 @@ var select = function( selector, context, results, seed, xml ) {
 		}
 
 
-		findContext = (tokens.length >= 1 && rsibling.test( tokens[0] ) && context.parentNode) || context;
+		findContext = (tokens.length >= 1 && (match = rsibling.exec( tokens[0] )) && !match.index && context.parentNode) || context;
 
 		// Get the last token, excluding :not
 		notTokens = tokens.pop();
@@ -1370,7 +1370,7 @@ if ( document.querySelectorAll ) {
 				} else if ( context.nodeType === 1 && context.nodeName.toLowerCase() !== "object" ) {
 					var old = context.getAttribute("id"),
 						nid = old || expando,
-						newContext = rsibling.test( selector ) ? context.parentNode : context;
+						newContext = rsibling.test( selector ) && context.parentNode || context;
 
 					if ( old ) {
 						nid = nid.replace( rescape, "\\$&" );

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -338,7 +338,7 @@ test("multiple", function() {
 });
 
 test("child and adjacent", function() {
-	expect( 40 );
+	expect( 42 );
 
 	t( "Child", "p > a", ["simon1","google","groups","mark","yahoo","simon"] );
 	t( "Child", "p> a", ["simon1","google","groups","mark","yahoo","simon"] );
@@ -369,6 +369,10 @@ test("child and adjacent", function() {
 	deepEqual( Sizzle("~ em", siblingFirst), q("siblingnext", "siblingthird"), "Element Preceded By with a context." );
 	deepEqual( Sizzle("+ em", siblingFirst), q("siblingnext"), "Element Directly Preceded By with a context." );
 	deepEqual( Sizzle("~ em:first", siblingFirst), q("siblingnext"), "Element Preceded By positional with a context." );
+
+	var en = document.getElementById("en");
+	deepEqual( Sizzle("+ p, a", en), q("yahoo", "sap"), "Compound selector with context, beginning with sibling test." );
+	deepEqual( Sizzle("a, + p", en), q("yahoo", "sap"), "Compound selector with context, containing sibling test." );
 
 	t( "Multiple combinators selects all levels", "#siblingTest em *", ["siblingchild", "siblinggrandchild", "siblinggreatgrandchild"] );
 	t( "Multiple combinators selects all levels", "#siblingTest > em *", ["siblingchild", "siblinggrandchild", "siblinggreatgrandchild"] );


### PR DESCRIPTION
Net effect on jQuery master @ [0d9006531d2b991cdbf419e1b4b0b4e03a588b10](https://github.com/jquery/jquery/commit/0d9006531d2b991cdbf419e1b4b0b4e03a588b10)

```
    256937      (-134)  dist/jquery.js                                         
     92257       (-47)  dist/jquery.min.js                                     
     32998       (-24)  dist/jquery.min.js.gz                                  
```
