### PR TITLE
Simplify contains function

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -761,24 +761,11 @@ var isXML = Sizzle.isXML = function( elem ) {
 };
 
 // Element contains another
-var contains = Sizzle.contains = docElem.compareDocumentPosition ?
-	function( a, b ) {
-		return !!( a.compareDocumentPosition( b ) & 16 );
-	} :
-	docElem.contains ?
-	function( a, b ) {
-		var adown = a.nodeType === 9 ? a.documentElement : a,
-			bup = b.parentNode;
-		return a === bup || !!( bup && bup.nodeType === 1 && adown.contains && adown.contains(bup) );
-	} :
-	function( a, b ) {
-		while ( (b = b.parentNode) ) {
-			if ( b === a ) {
-				return true;
-			}
-		}
-		return false;
-	};
+var contains = Sizzle.contains = function( a, b ) {
+	var adown = a.documentElement || a,
+		bup = b.parentNode;
+	return a === bup || !!( bup && bup.nodeType === 1 && adown.contains && adown.contains(bup) );
+};
 
 /**
  * Utility function for retrieving the text value of an array of DOM nodes


### PR DESCRIPTION
Node.contains is <a href="http://jsperf.com/compareposition-vs-contains">faster</a>, more appropriate for Sizzle.contains, and has support everywhere
