### PR TITLE
fixes #12492, is(:focus) fails in Chrome

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1429,8 +1429,8 @@ if ( document.querySelectorAll ) {
 			}
 		});
 
-		// rbuggyMatches always contains :focus, so no need for a length check
-		rbuggyMatches = /* rbuggyQSA.length && */ new RegExp( rbuggyQSA.join("|") );
+		// rbuggyQSA always contains :focus, so no need for a length check
+		rbuggyQSA = /* rbuggyQSA.length && */ new RegExp( rbuggyQSA.join("|") );
 
 		select = function( selector, context, results, seed, xml ) {
 			// Only use querySelectorAll when not filtering,


### PR DESCRIPTION
fixes issue coming from http://bugs.jquery.com/ticket/12492

I couldn't find a suitable unit test. @timmywil, any suggestions?
