### PR TITLE
Use String literals instead of String-Wrapped Objects for performance re...

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -1095,7 +1095,7 @@ function tokenize( selector, parseOnly ) {
 					val: matched,
 					type: type,
 					matches: match
-				});
+				} );
 				soFar = soFar.slice( matched.length );
 			}
 		}


### PR DESCRIPTION
...asons.

see #175

all unit tests pass
