### PR TITLE
Fix the slice check

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -136,7 +136,7 @@ var i,
 
 // Use a stripped-down slice if we can't use a native one
 try {
-	slice.call( window.document.documentElement.childNodes, 0 )[0].nodeType;
+	slice.call( preferredDoc.documentElement.childNodes, 0 )[0].nodeType;
 } catch ( e ) {
 	slice = function( i ) {
 		var elem,


### PR DESCRIPTION
As of 9751a47ded9693140af2aa635f7a9d928ac30a0b, `docElem` is not defined at the point of its use in the `slice` check, so it always fails, and the native `slice` never gets used.
