### PR TITLE
Make the native check support Rhino

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -109,7 +109,7 @@ var i,
 
 	rsibling = /[\x20\t\r\n\f]*[+~]/,
 
-	rnative = /\{\s*\[native code.*\]\s*\}/,
+	rnative = /^[^{]+\{\s*\[native code/,
 
 	// Easily-parseable/retrievable ID or TAG or CLASS selectors
 	rquickExpr = /^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,


### PR DESCRIPTION
In Rhino, native functions do not display as just `[native code]`, but
often with extra information, for example:

```
js> Array.prototype.slice
function slice() { [native code for Array.slice, arity=2] }
```
