### PR TITLE
Avoiding use of Dynamic Attributes with innerHTML

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -376,7 +376,6 @@ setDocument = Sizzle.setDocument = function( node ) {
 	support.getByName = assert(function( div ) {
 		// Inject content
 		div.id = expando + 0;
-		div.innerHTML = "";
 		// Windows 8 Native Apps consider the `name` attr 'unsafe' when
 		// passed to innerHTML with a string of arbitrary markup
 		// http://msdn.microsoft.com/en-us/library/ie/hh465388.aspx


### PR DESCRIPTION
Some environments (such as Windows 8 Store Apps) will not permit the use of
innerHTML along with dynamic attributes like 'name'. You can, however,
set them via the setAttribute method. This should help those migrating
their code from the browser to a native application.

Pinging @dmethvin
