### PR TITLE
Further avoidance of problematic innerHTML assignment

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -552,6 +552,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 			// Opera 10-12/IE8 - ^= $= *= and empty values
 			// Should not select anything
+			// In Windows 8 you cannot use the type attribute during .innerHTML assignment
+			// As such, we have instead gone the createElement/setAttribute route
 			var input = document.createElement("input");
 			input.setAttribute("type", "hidden");
 			input.setAttribute("i", "");


### PR DESCRIPTION
Within the Windows 8 Environment, the `type` attribute on `input` elements in considered unsafe (source: [msdn](http://msdn.microsoft.com/en-us/library/ie/hh465388.aspx)). As such, it cannot be set during assignment using `.innerHTML`.

For a previous example in Sizzle, see https://github.com/jquery/sizzle/commit/b576034ab6c7442719fb74d687551bb1478d822e.
