### PR TITLE
Replace deprecated Grunt directives

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,10 +51,10 @@ module.exports = function( grunt ) {
 		},
 		watch: {
 			files: [
-				"<config:jshint.source.src>",
-				"<config:jshint.grunt.src>",
-				"<config:jshint.speed.src>",
-				"<config:jshint.tests.src>"
+				"<%= jshint.source.src %>",
+				"<%= jshint.grunt.src %>",
+				"<%= jshint.speed.src %>",
+				"<%= jshint.tests.src %>"
 			],
 			tasks: "default"
 		}


### PR DESCRIPTION
Per https://github.com/gruntjs/grunt/wiki/Upgrading-from-0.3-to-0.4,
directives are now removed/deprecated and have been replaced with these
templates
