### PR TITLE
Convert selectors to W3C like to try QSA better

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -140,6 +140,53 @@ var i,
 				String.fromCharCode( high + 0x10000 ) :
 				// Supplemental Plane codepoint (surrogate pair)
 				String.fromCharCode( high >> 10 | 0xD800, high & 0x3FF | 0xDC00 );
+	},
+
+	QSAMap = {
+		":button":"button,input[type=button]",
+		":checkbox":"[type=checkbox]"
+	},
+
+	qsalize = function( selectorsGroupFrom ) {
+		var selectorsGroupTo = "",
+			selectorFromArray = selectorsGroupFrom.split( "," ),
+			selectorFromIndex,
+			workArray,
+			workArrayIndex,
+			tempArray,
+			QSAArray,
+			QSAArrayIndex,
+			QSAMapKey,
+			needProcess;
+
+		for ( selectorFromIndex in selectorFromArray ) {
+			workArray = [selectorFromArray[selectorFromIndex]];
+
+			for ( QSAMapKey in QSAMap ) {
+				needProcess = true;
+				while ( needProcess ) {
+					tempArray = [];
+					needProcess = false;
+					for ( workArrayIndex in workArray ) {
+						if ( workArray[workArrayIndex].match( QSAMapKey ) ) {
+							QSAArray = QSAMap[QSAMapKey].split(",");
+							for ( QSAArrayIndex in QSAArray ) {
+								tempArray.push( workArray[workArrayIndex].replace(QSAMapKey, QSAArray[QSAArrayIndex]) );
+							}
+							needProcess = true;
+						} else {
+							tempArray.push( workArray[workArrayIndex] );
+						}
+					}
+
+					workArray = tempArray;
+				}
+			}
+
+			selectorsGroupTo += workArray.join( "," );
+		}
+
+		return selectorsGroupTo;
 	};
 
 // Optimize for push.apply( _, NodeList )
@@ -321,7 +368,7 @@ function Sizzle( selector, context, results, seed ) {
 			if ( newSelector ) {
 				try {
 					push.apply( results,
-						newContext.querySelectorAll( newSelector )
+						newContext.querySelectorAll( qsalize( newSelector ) )
 					);
 					return results;
 				} catch(qsaError) {


### PR DESCRIPTION
Some selectors have equivalent W3C counterparts, such that ":button" can
be mapped to "button, input[type=button]", and ":checkbox" can be mapped
to "[type=checkbox]". If we take this kind of conversion before calling
QSA, we may have more chance to take the advantage of performance boost
by the native DOM QSA. This patch is to add such an engine to facilitate
the conversion.

Some test results (Note the data had small fluctuation from time to time):
":button"
Before change: ~1020o/s
After change: ~6060o/s

":checkbox"
Before change: ~1130o/s
After change: ~5340o/s
