### PR TITLE
Fix bugs with uncaught exception handling.

### DIFF
--- a/sizzle.js
+++ b/sizzle.js
@@ -635,8 +635,12 @@ setDocument = Sizzle.setDocument = function( node ) {
 			}
 
 			// Opera 10-11 does not throw on post-comma invalid pseudos
-			div.querySelectorAll("*,:x");
-			rbuggyQSA.push(",.*:");
+			try {
+				div.querySelectorAll("*,:x");
+				rbuggyQSA.push(",.*:");
+			} catch( e ) {
+				return false;
+			}
 		});
 	}
 
@@ -652,8 +656,12 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 			// This should fail with an exception
 			// Gecko does not error, returns false instead
-			matches.call( div, "[s!='']:x" );
-			rbuggyMatches.push( "!=", pseudos );
+			try {
+				matches.call( div, "[s!='']:x" );
+				rbuggyMatches.push( "!=", pseudos );
+			} catch( e ) {
+				return false;
+			}
 		});
 	}
 


### PR DESCRIPTION
Safari and IE stop on these lines because of some weird jQuery behaviour.

http://stackoverflow.com/questions/15145108/running-jquery-crashing-on-ie10-win7

http://bugs.jquery.com/ticket/13881

![screen shot 2013-07-19 at 12 49 52](https://f.cloud.github.com/assets/574696/825032/e0373b52-f058-11e2-9857-75b3f0991f2b.png)
