### PR TITLE
clear input for uniqueSort after sorting to prevent memory leak

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -875,6 +875,9 @@ Sizzle.uniqueSort = function( results ) {
 		}
 	}
 
+	// clear input after sorting to prevent memory leak
+	sortInput = undefined;
+
 	return results;
 };
 


### PR DESCRIPTION
The sortInput makes memory leakage for last sorting.
I have found memory leakage while using jQuery.
