### PR TITLE
Remove useless delete statement

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -544,10 +544,6 @@ setDocument = Sizzle.setDocument = function( node ) {
 			};
 		};
 	} else {
-		// Support: IE6/7
-		// getElementById is not reliable as a find shortcut
-		delete Expr.find["ID"];
-
 		Expr.filter["ID"] =  function( id ) {
 			var attrId = id.replace( runescape, funescape );
 			return function( elem ) {


### PR DESCRIPTION
I'm not sure how relevant the support comment is, however `Expr.find["ID"]` is only set in the if block above the else, so if the else block is ever entered, `Expr.find["ID"]` will not exist which makes this delete pointless.
