### PR TITLE
Build: Update devDependencies & jsHint configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -110,29 +110,11 @@ module.exports = function( grunt ) {
 			"test/libs/qunit": "qunit/qunit"
 		},
 		jshint: {
-			source: {
-				src: files.source,
-				options: {
-					jshintrc: "src/.jshintrc"
-				}
+			options: {
+				jshintrc: true
 			},
-			build: {
-				src: [ files.grunt, files.karma ],
-				options: {
-					jshintrc: ".jshintrc"
-				}
-			},
-			speed: {
-				src: files.speed,
-				options: {
-					jshintrc: "speed/.jshintrc"
-				}
-			},
-			tests: {
-				src: files.tests,
-				options: {
-					jshintrc: "test/.jshintrc"
-				}
+			all: {
+				src: [ files.source, files.grunt, files.karma, files.speed, files.tests ]
 			}
 		},
 		jscs: {

--- a/package.json
+++ b/package.json
@@ -24,28 +24,28 @@
 	"dependencies": {},
 	"devDependencies": {
 		"commitplease": "1.7.0",
-		"grunt": "0.4.2",
-		"grunt-bowercopy": "0.5.0",
-		"grunt-cli": "0.1.11",
+		"grunt": "0.4.4",
+		"grunt-bowercopy": "1.0.0",
+		"grunt-cli": "0.1.13",
 		"grunt-compare-size": "0.4.0",
-		"grunt-contrib-jshint": "0.7.2",
-		"grunt-contrib-qunit": "0.3.0",
-		"grunt-contrib-uglify": "0.2.7",
-		"grunt-contrib-watch": "0.5.3",
-
-		"grunt-compare-size": "0.4.0",
-
+		"grunt-contrib-jshint": "0.10.0",
+		"grunt-contrib-qunit": "0.4.0",
+		"grunt-contrib-uglify": "0.4.0",
+		"grunt-contrib-watch": "0.6.1",
 		"grunt-git-authors": "1.2.0",
 		"grunt-jscs-checker": "0.4.1",
 		"grunt-jsonlint": "1.0.4",
+		"grunt-karma": "0.8.3",
 		"gzip-js": "0.3.2",
-		"load-grunt-tasks": "0.2.1",
-
-		"grunt-karma": "0.8.2",
-		"karma-qunit": "0.1.1",
+		"karma": "0.12.14",
 		"karma-browserstack-launcher": "0.0.8",
+		"karma-chrome-launcher": "0.1.3",
+		"karma-firefox-launcher": "0.1.3",
+		"karma-html2js-preprocessor": "0.1.0",
 		"karma-phantomjs-launcher": "0.1.4",
-		"karma-html2js-preprocessor": "0.1.0"
+		"karma-qunit": "0.1.1",
+		"load-grunt-tasks": "0.4.0",
+		"qunitjs": "1.12.0"
 	},
 
 	"scripts": {

--- a/test/karma/.jshintrc
+++ b/test/karma/.jshintrc
@@ -1,0 +1,17 @@
+{
+	"boss": true,
+	"curly": true,
+	"eqeqeq": true,
+	"eqnull": true,
+	"expr": true,
+	"immed": true,
+	"noarg": true,
+	"onevar": true,
+	"quotmark": "double",
+	"smarttabs": true,
+	"trailing": true,
+	"undef": true,
+	"unused": true,
+
+	"node": true
+}


### PR DESCRIPTION
It's a good practice to list peerDependencies directly in package.json,
especially that current auto-installing behavior will go away in future
versions of npm: https://github.com/npm/npm/issues/5080

Also, jsHint plugin should search for proper .jshintrc files on its own;
current behavior integrated badly with IDEs in some cases.

cc @markelog
