### PR TITLE
Build: Increase disconnect tolerance in Karma config

### DIFF
--- a/test/karma/karma.conf.js
+++ b/test/karma/karma.conf.js
@@ -71,7 +71,9 @@ module.exports = function( config ) {
 
 		// If browser does not capture in given timeout [ms], kill it
 		captureTimeout: 3e5,
-		browserNoActivityTimeout: 3e5
+		browserNoActivityTimeout: 3e5,
+		browserDisconnectTimeout: 3e5,
+		browserDisconnectTolerance: 3
 	});
 
 	// Deal with Travis environment


### PR DESCRIPTION
So far, in case of a browser being disconnected from Karma we are getting
a failure. Since it happens quite often, especially for slower browsers,
increase the disconnect tolerance to 3 times.

cc @markelog

I'm not sure if it works in Karma 0.10 so it's better to merge #259 first.
