### PR TITLE
Build: Add more tested browsers, update existing ones

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,27 +25,35 @@ module.exports = function( grunt ) {
 		// See https://github.com/jquery/sizzle/wiki/Sizzle-Documentation#browsers
 
 		browsers.desktop = [
-			"bs_chrome-32", "bs_chrome-33",
+			"bs_chrome-34", "bs_chrome-35",
 
+			"bs_firefox-17", "bs_firefox-24", // Firefox ESR
 			"bs_firefox-28", "bs_firefox-29",
 
 			"bs_ie-9", "bs_ie-10", "bs_ie-11",
 
-			"bs_opera-19", "bs_opera-20",
+			"bs_opera-20", "bs_opera-21",
 
-			"bs_safari-6.1", "bs_safari-7"
+			"bs_safari-6.0", "bs_safari-6.1", "bs_safari-7.0"
 		];
 
 		browsers.old = [
-			"bs_ie-6", "bs_ie-7", "bs_ie-8"
+			// Node.js 0.10 has the same v8 version as Chrome 24
+			"bs_chrome-14", "bs_chrome-24",
+
+			"bs_firefox-3.6",
+
+			"bs_ie-6", "bs_ie-7", "bs_ie-8",
 
 			// Opera 12.16 temporary unavailable on BS through Karma launcher
-			//,"bs_opera-12.16"
+			//,"bs_opera-12.16",
+
+			"bs_safari-4.0", "bs_safari-5.0", "bs_safari-5.1"
 		];
 
-		browsers.ios = [ "bs_ios-6", "bs_ios-7" ];
+		browsers.ios = [ "bs_ios-5.1", "bs_ios-6.0", "bs_ios-7.0" ];
 		browsers.oldAndroid = [ "bs_android-2.3" ];
-		browsers.newAndroid = [ "bs_android-4.1" ];
+		browsers.newAndroid = [ "bs_android-4.0", "bs_android-4.1", "bs_android-4.2" ];
 	}
 
 	// Project configuration.

--- a/test/karma/launchers.js
+++ b/test/karma/launchers.js
@@ -1,6 +1,27 @@
 "use strict";
 
 module.exports = {
+	"bs_firefox-3.6": {
+		base: "BrowserStack",
+		browser: "firefox",
+		browser_version: "3.6",
+		os: "OS X",
+		os_version: "Mavericks"
+	},
+	"bs_firefox-17": {
+		base: "BrowserStack",
+		browser: "firefox",
+		browser_version: "17.0",
+		os: "OS X",
+		os_version: "Mavericks"
+	},
+	"bs_firefox-24": {
+		base: "BrowserStack",
+		browser: "firefox",
+		browser_version: "24.0",
+		os: "OS X",
+		os_version: "Mavericks"
+	},
 	"bs_firefox-28": {
 		base: "BrowserStack",
 		browser: "firefox",
@@ -16,17 +37,31 @@ module.exports = {
 		os_version: "Mavericks"
 	},
 
-	"bs_chrome-32": {
+	"bs_chrome-14": {
 		base: "BrowserStack",
 		browser: "chrome",
-		browser_version: "32.0",
+		browser_version: "14.0",
 		os: "OS X",
 		os_version: "Mavericks"
 	},
-	"bs_chrome-33": {
+	"bs_chrome-24": {
 		base: "BrowserStack",
 		browser: "chrome",
-		browser_version: "33.0",
+		browser_version: "24.0",
+		os: "OS X",
+		os_version: "Mavericks"
+	},
+	"bs_chrome-34": {
+		base: "BrowserStack",
+		browser: "chrome",
+		browser_version: "34.0",
+		os: "OS X",
+		os_version: "Mavericks"
+	},
+	"bs_chrome-35": {
+		base: "BrowserStack",
+		browser: "chrome",
+		browser_version: "35.0",
 		os: "OS X",
 		os_version: "Mavericks"
 	},
@@ -81,13 +116,6 @@ module.exports = {
 		os: "Windows",
 		os_version: "8.1"
 	},
-	"bs_opera-19": {
-		base: "BrowserStack",
-		browser: "opera",
-		browser_version: "19.0",
-		os: "OS X",
-		os_version: "Mavericks"
-	},
 	"bs_opera-20": {
 		base: "BrowserStack",
 		browser: "opera",
@@ -95,11 +123,39 @@ module.exports = {
 		os: "OS X",
 		os_version: "Mavericks"
 	},
+	"bs_opera-21": {
+		base: "BrowserStack",
+		browser: "opera",
+		browser_version: "21.0",
+		os: "OS X",
+		os_version: "Mavericks"
+	},
 
+	"bs_safari-4.0": {
+		base: "BrowserStack",
+		browser: "safari",
+		browser_version: "4.0",
+		os: "OS X",
+		os_version: "Snow Leopard"
+	},
+	"bs_safari-5.0": {
+		base: "BrowserStack",
+		browser: "safari",
+		browser_version: "5.0",
+		os: "OS X",
+		os_version: "Snow Leopard"
+	},
 	"bs_safari-5.1": {
 		base: "BrowserStack",
 		browser: "safari",
 		browser_version: "5.1",
+		os: "OS X",
+		os_version: "Lion"
+	},
+	"bs_safari-6.0": {
+		base: "BrowserStack",
+		browser: "safari",
+		browser_version: "6.0",
 		os: "OS X",
 		os_version: "Lion"
 	},
@@ -110,7 +166,7 @@ module.exports = {
 		os: "OS X",
 		os_version: "Mountain Lion"
 	},
-	"bs_safari-7": {
+	"bs_safari-7.0": {
 		base: "BrowserStack",
 		browser: "safari",
 		browser_version: "7.0",
@@ -118,13 +174,19 @@ module.exports = {
 		os_version: "Mavericks"
 	},
 
-	"bs_ios-6": {
+	"bs_ios-5.1": {
+		base: "BrowserStack",
+		device: "iPhone 4S",
+		os: "ios",
+		os_version: "5.1"
+	},
+	"bs_ios-6.0": {
 		base: "BrowserStack",
 		device: "iPhone 5",
 		os: "ios",
 		os_version: "6.0"
 	},
-	"bs_ios-7": {
+	"bs_ios-7.0": {
 		base: "BrowserStack",
 		device: "iPhone 5S",
 		os: "ios",
@@ -137,10 +199,22 @@ module.exports = {
 		os: "android",
 		os_version: "2.3"
 	},
+	"bs_android-4.0": {
+		base: "BrowserStack",
+		device: "Motorola Razr",
+		os: "android",
+		os_version: "4.0"
+	},
 	"bs_android-4.1": {
 		base: "BrowserStack",
 		device: "Google Nexus 7",
 		os: "android",
 		os_version: "4.1"
+	},
+	"bs_android-4.2": {
+		base: "BrowserStack",
+		device: "LG Nexus 4",
+		os: "android",
+		os_version: "4.2"
 	}
 };


### PR DESCRIPTION
Firefox: I added 3.6 and last two ESRs. Firefox 3.0 errors with `Some of your tests did a full page reload`. Do we want to keep supporting 3.0? We'll need to fix sth if we do; otherwise, Firefox 3.6 is old enough. (EDIT: no longer true: Firefox 29 consistently disconnects, if it starts at all, it stops at 23/35 so I couldn't update the version here. Any ideas? Can it be our bug?)

Chrome: 4.0 doesn't even exist in BrowserStack, the oldest available is 14. Is it enough? Would it be OK to bump minimal supported version to it? I added v24 as well since it shares v8 version with Node 0.10.

Safari: Added 4.0, 5.0, 5.1 & 6.0. Removed 6.1 since it shares the same engine version with 7.0 and we're already testing _a lot_. I know @markelog was opposed to removing in case they start differing but I don't think we should guard ourselves so much about such potential stupidity on WebKit part, especially that we don't test all 26 supported Firefox versions etc. and we already have a lot of browsers. If the rest of you feel similarly to @markelog, I'll bring 6.1 back.

Opera: tried 11.6, 12.0 & 12.6 but it still doesn't connect. @markelog, did you contact BrowserStack about it? Did they reply?

iOS: Added 5.1 to current 6.0 & 7.0.

Android: Added 4.0 & 4.2 to current 2.3 & 4.1.
