### PR TITLE
Build: Append the date to local build names

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ module.exports = function( grunt ) {
 	// Project configuration.
 	grunt.initConfig({
 		pkg: grunt.file.readJSON( "package.json" ),
+		dateString: new Date().toISOString().replace( /\..*Z/, "" ),
 		compile: {
 			all: {
 				dest: "dist/sizzle.js",

--- a/test/karma/karma.conf.js
+++ b/test/karma/karma.conf.js
@@ -1,12 +1,15 @@
 "use strict";
 
+var grunt = require( "grunt" );
+
 module.exports = function( config ) {
-	var isTravis = process.env.TRAVIS;
+	var isTravis = process.env.TRAVIS,
+		dateString = grunt.config( "dateString" );
 
 	config.set({
 		browserStack: {
 			project: "sizzle",
-			build: "local run",
+			build: "local run" + (dateString ? ", " + dateString : ""),
 			timeout: 600 // 10 min
 		},
 


### PR DESCRIPTION
All local runs have been so far appearing under a build called "local run",
supposedly running for 121 days now and failing. Separating runs helps with
the organization and allows to see the result of a particular run at a glance.

We could also optionally append the user name if present. Thoughts?
