### PR TITLE
Test: dynamic HTTP responses for unit tests

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -12,6 +12,8 @@
 
 	jQuery( "body" ).attr( "id", "body" );
 
+	QUnit.config.testTimeout = 60000;
+
 	// Look for karma template, if found, we are in the karma suite
 	if ( window.__html__ ) {
 		document.body.innerHTML = window.__html__[ "test/data/fixtures.html" ];

--- a/test/karma/dynamic.js
+++ b/test/karma/dynamic.js
@@ -1,0 +1,41 @@
+"use strict";
+
+var url = require( "url" );
+
+function dynamicResponder( config, logger, customFileHandlers ) {
+	var log = logger.create( "framework.dynamicResponder" ),
+		responderConfig = config.dynamicResponder || {},
+		path = responderConfig.path || "/dynamic",
+		rheader = /^header:(.+)$/;
+
+	log.info( "Registering dynamic responder for path: " + path );
+
+	customFileHandlers.push({
+		urlRegex: new RegExp( "^" + path.replace( /\W/g, "\\$&" ) + "(?:\\?|$)" ),
+		handler: function( request, response ) {
+			var params = url.parse( request.url, true ).query;
+
+			Object.keys( params ).forEach(function( param ) {
+				var header = rheader.exec( param );
+				if ( header ) {
+					response.setHeader( header[ 1 ], params[ param ] );
+				}
+			});
+
+			if ( "statusCode" in params ) {
+				response.statusCode = params.statusCode;
+			}
+			response.end( params.body || "" );
+		}
+	});
+
+	// Return a no-op reporter
+	return {};
+}
+// DI PARAMETER MAPPING
+dynamicResponder.$inject = [ "config", "logger", "customFileHandlers" ];
+
+// PUBLISH DI MODULE
+module.exports = {
+	"framework:dynamicResponse": [ "type", dynamicResponder ]
+};

--- a/test/karma/karma.conf.js
+++ b/test/karma/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function( config ) {
 		// that will break iframe tests
 		basePath: "../../",
 
-		frameworks: [ "qunit" ],
+		frameworks: [ "qunit", "dynamicResponse" ],
 
 		files: [
 			"external/jquery/jquery.js",
@@ -46,6 +46,7 @@ module.exports = function( config ) {
 			}
 		],
 
+		plugins: [ "karma-*", require("./dynamic") ],
 		preprocessors: {
 
 			// mixed_sort.html downloaded through iframe inclusion
@@ -58,7 +59,7 @@ module.exports = function( config ) {
 		customLaunchers: require( "./launchers" ),
 
 		// Make travis output less verbose
-		reporters: isTravis ? "dots" : "progress",
+		reporters: [ isTravis ? "dots" : "progress" ],
 
 		colors: !isTravis,
 


### PR DESCRIPTION
cc @markelog 

While running around in circles for #279, I briefly thought the issue was connected to `X-Frame-Options` and had no reliable means of getting it to the client. This abuse of karma resolves that. I'd like to land it for now and open tickets and/or PRs against https://github.com/karma-runner/karma to make it unnecessary, but wanted to open it up for discussion first.
