### PR TITLE
Wiki: Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 __A pure-JavaScript CSS selector engine designed to be easily dropped in to a host library.__
 
 - [More information](http://sizzlejs.com/)
-- [Documentation](https://github.com/jquery/sizzle/wiki/Sizzle-Documentation)
-- [Browser support](https://github.com/jquery/sizzle/wiki/Sizzle-Documentation#wiki-browsers)
+- [Documentation](https://github.com/jquery/sizzle/wiki/)
+- [Browser support](https://github.com/jquery/sizzle/wiki/#wiki-browsers)
 
 Contribution Guides
 ---------------------------


### PR DESCRIPTION
Updated the Sizzle docs to better fit the jQuery documentation style guide. Also fixed a number of syntactical and spelling errors.

Unfortunately, GitHub is a little weird in regards to Wiki contribution for non-org-members, so I've had to disguise these changes as a modification to the documentation link path in README.md (didn't bother branching it). Have filed a bug report with GitHub. 

The actual changes are in https://github.com/neftaly/sizzle/wiki (https://github.com/neftaly/sizzle.wiki.git). Suggest doing a manual pull/push on sizzle.wiki to keep the changelog intact, though you could also just copy & paste [Home.md](https://github.com/neftaly/sizzle/wiki/Home.md).

Thanks!