### PR TITLE
Make JSdoc return type of createCache comply with type syntax

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -300,7 +300,7 @@ function Sizzle( selector, context, results, seed ) {
 
 /**
  * Create key-value caches of limited size
- * @returns {Function(string, Object)} Returns the Object data after storing it on itself with
+ * @returns {function(string, object)} Returns the Object data after storing it on itself with
  *	property name the (space-suffixed) string and (if the cache is larger than Expr.cacheLength)
  *	deleting the oldest entry
  */


### PR DESCRIPTION
Google Closure Compiler complains about the line in question because it uses uppercase types. Defining them in lowercase makes Sizzle and subsequently jQuery be compilable with Closure Compiler even when type checking is set to error level.