### PR TITLE
Test: Class selector on SVG Elements jquery/sizzle#322

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -252,7 +252,7 @@ test("id", function() {
 });
 
 test("class", function() {
-	expect( 26 );
+	expect( 27 );
 
 	t( "Class Selector", ".blog", ["mark","simon"] );
 	t( "Class Selector", ".GROUPS", ["groups"] );
@@ -295,6 +295,10 @@ test("class", function() {
 
 	div = jQuery("<div><svg width='200' height='250' version='1.1' xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30' class='foo'></rect></svg></div>")[0];
 	equal( Sizzle(".foo", div).length, 1, "Class selector against SVG" );
+
+	var svg = document.createElement("svg");
+	svg = jQuery("<svg width='200' height='250' version='1.1' xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30' class='foo'></rect></svg>")[0];
+	equal( Sizzle(".foo", svg).length, 1, "Class selector on SVG Element" );
 });
 
 test("name", function() {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -294,11 +294,8 @@ test("class", function() {
 	deepEqual( Sizzle(".e.hasOwnProperty.toString", div), [ div.lastChild ], "Classes match Object.prototype properties" );
 
 	div = jQuery("<div><svg width='200' height='250' version='1.1' xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30' class='foo'></rect></svg></div>")[0];
-	equal( Sizzle(".foo", div).length, 1, "Class selector against SVG" );
-
-	var svg = document.createElement("svg");
-	svg = jQuery("<svg width='200' height='250' version='1.1' xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30' class='foo'></rect></svg>")[0];
-	equal( Sizzle(".foo", svg).length, 1, "Class selector on SVG Element" );
+	equal( Sizzle(".foo", div).length, 1, "Class selector against SVG container" );
+	equal( Sizzle(".foo", div.firstChild).length, 1, "Class selector directly against SVG" );
 });
 
 test("name", function() {


### PR DESCRIPTION
Test case for #322

I ran it through browserstack and the test fails in all Internet Explorer:
- IE 9.0.0 (Windows Vista) selector class FAILED
- IE 10.0.0 (Windows 8) selector class FAILED
- IE 11.0.0 (Windows 8.1) selector class FAILED

Every other test runs successfully:
Chrome 38.0.2125 (Mac OS X 10.10.1): Executed 46 of 46 SUCCESS (2.356 secs / 1.91 secs)
Firefox 31.0.0 (Mac OS X 10.9): Executed 46 of 46 SUCCESS (2.344 secs / 1.788 secs)
Firefox 34.0.0 (Mac OS X 10.10): Executed 46 of 46 SUCCESS (2.272 secs / 1.955 secs)
Firefox 24.0.0 (Mac OS X 10.9): Executed 46 of 46 SUCCESS (2.37 secs / 1.587 secs)
Chrome 39.0.2171 (Mac OS X 10.10.1): Executed 46 of 46 SUCCESS (2.33 secs / 1.649 secs)
Firefox 35.0.0 (Mac OS X 10.10): Executed 46 of 46 SUCCESS (2.347 secs / 1.8 secs)
Opera 25.0.1614 (Mac OS X 10.10.1): Executed 46 of 46 SUCCESS (2.264 secs / 1.814 secs)
Opera 26.0.1656 (Mac OS X 10.10.1): Executed 46 of 46 SUCCESS (2.29 secs / 1.918 secs)
Yandex Browser 14.12.2125 (Mac OS X 10.10.1): Executed 46 of 46 SUCCESS (2.561 secs / 2.413 secs)
Safari 6.1.0 (Mac OS X 10.8.5): Executed 46 of 46 SUCCESS (2.257 secs / 1.622 secs)
Safari 7.0.6 (Mac OS X 10.9.5): Executed 46 of 46 SUCCESS (2.329 secs / 1.178 secs)
Safari 6.0.5 (Mac OS X 10.7.5): Executed 46 of 46 SUCCESS (40.62 secs / 40.445 secs)
Safari 8.0.0 (Mac OS X 10.10.1): Executed 46 of 46 SUCCESS (2.28 secs / 1.466 secs)