### PR TITLE
Fix typos/usage: descendent => descendant

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -731,7 +731,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	hasCompare = rnative.test( docElem.compareDocumentPosition );
 
 	// Element contains another
-	// Purposefully does not implement inclusive descendent
+	// Purposefully self-exclusive
 	// As in, an element does not contain itself
 	contains = hasCompare || rnative.test( docElem.contains ) ?
 		function( a, b ) {

--- a/test/data/fixtures.html
+++ b/test/data/fixtures.html
@@ -84,7 +84,7 @@
 		<span id="台北" lang="中文"></span>
 		<span id="utf8class1" class="台北Táiběi 台北">"'台北Táiběi"'</span>
 		<span id="utf8class2" class="台北"></span>
-		<span id="foo:bar" class="foo:bar"><span id="foo_descendent"></span></span>
+		<span id="foo:bar" class="foo:bar"><span id="foo_descendant"></span></span>
 		<span id="test.foo[5]bar" class="test.foo[5]bar"></span>
 
 		<foo_bar id="foobar">test element</foo_bar>

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -108,8 +108,8 @@ test("element", function() {
 		html = "<div>" + html + "</div>";
 	}
 	html = jQuery( html ).appendTo( document.body );
-	ok( !!Sizzle("body div div div").length, "No stack or performance problems with large amounts of descendents" );
-	ok( !!Sizzle("body>div div div").length, "No stack or performance problems with large amounts of descendents" );
+	ok( !!Sizzle("body div div div").length, "No stack or performance problems with large amounts of descendants" );
+	ok( !!Sizzle("body>div div div").length, "No stack or performance problems with large amounts of descendants" );
 	html.remove();
 
 	// Real use case would be using .watch in browsers with window.watch (see Issue #157)
@@ -212,7 +212,7 @@ test("id", function() {
 	t( "Child ID selector using UTF8", "form > #台北", ["台北"] );
 
 	t( "Escaped ID", "#foo\\:bar", ["foo:bar"] );
-	t( "Escaped ID with descendent", "#foo\\:bar span:not(:input)", ["foo_descendent"] );
+	t( "Escaped ID with descendant", "#foo\\:bar span:not(:input)", ["foo_descendant"] );
 	t( "Escaped ID", "#test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );
 	t( "Descendant escaped ID", "div #foo\\:bar", ["foo:bar"] );
 	t( "Descendant escaped ID", "div #test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );


### PR DESCRIPTION
> The correct spelling for the noun meaning 'person descended from
> a particular ancestor' is descendant, not -ent.
– http://www.oxforddictionaries.com/us/definition/english/descendant