### PR TITLE
Define the local document

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -24,7 +24,7 @@ var i,
 
 	// Local document vars
 	setDocument,
-	document,
+	document = window.document,
 	docElem,
 	documentIsHTML,
 	rbuggyQSA,


### PR DESCRIPTION
Sizzle creates a local variable `document`, however it remains unset at
startup so assertions will throw if there isn't a global `document`,
such as in Node. Defining the initial value of the document `var` fixes
this.

Closes #343