### PR TITLE
Build: don't assume the browser environment; drop old JSHint options

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-compare-size": "0.4.0",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-qunit": "0.5.2",
     "grunt-contrib-uglify": "0.5.1",
     "grunt-contrib-watch": "0.6.1",

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -6,21 +6,21 @@
 	"expr": true,
 	"immed": true,
 	"noarg": true,
-	"onevar": true,
 	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 
-	"regexdash": true,
 	"sub": true,
 
-	"browser": true,
+	// Support: IE < 10, Android < 4.1
+	// The above browsers are failing a lot of tests in the ES5
+	// test suite at http://test262.ecmascript.org.
 	"es3": true,
-	"wsh": true,
 
 	"globals": {
+		"window": true,
+		"JSON": false,
+
 		"define": false,
 		"module": false,
 		"require": false,


### PR DESCRIPTION
Fixes gh-345

This turned out to be easy. No source changes required. :)