### PR TITLE
Sizzle: warn on selector de-optimization

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -310,6 +310,12 @@ function Sizzle( selector, context, results, seed ) {
 						nid = nid.replace( rcssescape, fcssescape );
 					} else {
 						context.setAttribute( "id", (nid = expando) );
+						if ( typeof console !== "undefined" && console.warn ) {
+							console.warn("The selector " + selector + " has been de-optimized due to an inability to run " +
+								"native querySelectorAll() or to use an id on the parent. This will lead to a style " +
+								"recalculation and may cause poor performance. Please consider adding an id to the " +
+								"parent element or using a simpler selector.");
+						}
 					}
 
 					// Prefix every selector in the list


### PR DESCRIPTION
When this code path is reached, a `setAttribute("id")` is called followed by removing that same attribute. Since we are mutating the DOM, this will cause a style recalculation, which can be very expensive in certain scenarios. It may also be surprising to users, since they might not expect an `$element.find()` to cause DOM mutations. This PR adds a console warning when the de-optimized code path is reached.

Here is [a minimal repro](http://bl.ocks.org/nolanlawson/247b71a2c7bba0a21d8cfe1ccb0d20ab) to demonstrate the cost of the de-optimized Sizzle selector (e.g. `$el.find('> .foo')`) vs the native selector (e.g. `$el.find('.foo')`). If you profile it in Edge 14, you'll see an added style recalculation when we're using the non-native selector:

![f12](https://cloud.githubusercontent.com/assets/283842/19987054/69f871ee-a1d6-11e6-8e59-36feb822fc6a.png)

(The performance hit should be similar in IE.)

In Chrome 54 I wasn't able to find an explicit extra style recalculation (maybe they've optimized for the randomized id since it doesn't match any CSS rules?) but in any case the non-native selector code is decidedly slower:

![devtools](https://cloud.githubusercontent.com/assets/283842/19987076/89cedc7e-a1d6-11e6-8c79-38084caea2d9.png)

(That's 5.71ms for the Sizzle selector vs 2.85ms for the native. I took all these screenshots on an i5 Surface Book 1.)

In this particular repro the added costs may not seem very high, but I recently profiled a major webapp (won't say who, in order to protect the guilty :wink:) and this codepath caused a _huge_ performance problem with lots of added style recalculations that were very expensive and slowed the app down to a crawl.

I'm not sure what the ideal solution is (I couldn't think of an alternative to adding and removing the `id`), but it seems reasonable to just `console.warn()` so that folks are aware they can either 1) choose a more efficient selector, or 2) add an `id` to the parent. OTOH the warning message alone may be a bit cryptic, so perhaps we should link back to a wiki page or something to explain the problem? I'm open to suggestions; this is just a first pass. 🙂 