### PR TITLE
Avoid "matchExpr[type].exec is not a function".

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -1672,7 +1672,9 @@ tokenize = Sizzle.tokenize = function( selector, parseOnly ) {
 
 		// Filters
 		for ( type in Expr.filter ) {
-			if ( (match = matchExpr[ type ].exec( soFar )) && (!preFilters[ type ] ||
+			if ( Expr.filter.hasOwnProperty(type) &&
+			    	matchExpr.hasOwnProperty(type) &&
+			    	(match = matchExpr[ type ].exec( soFar )) && (!preFilters[ type ] ||
 				(match = preFilters[ type ]( match ))) ) {
 				matched = match.shift();
 				tokens.push({


### PR DESCRIPTION
When extending `Object.prototype`, a `TypeError` may occur in `Sizzle.tokenize`, because `type` so far wasn't checked using `hasOwnProperty`.