### PR TITLE
speed up the tokenise

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -1646,16 +1646,16 @@ tokenize = Sizzle.tokenize = function( selector, parseOnly ) {
 	groups = [];
 	preFilters = Expr.preFilter;
 
-	while ( soFar ) {
+	// Comma
+	if ( (match = rcomma.exec( soFar )) && match ) {
+		// Don't consume trailing commas as valid
+		soFar = soFar.slice( match[0].length ) || soFar;
+	}
+	
+	// do this on before looping
+	groups.push( (tokens = []) );
 
-		// Comma and first run
-		if ( !matched || (match = rcomma.exec( soFar )) ) {
-			if ( match ) {
-				// Don't consume trailing commas as valid
-				soFar = soFar.slice( match[0].length ) || soFar;
-			}
-			groups.push( (tokens = []) );
-		}
+	while ( soFar ) {
 
 		matched = false;
 


### PR DESCRIPTION
by sourcing out the comma on start and the firstrun the loop does not compute the if sequence on every run.

in the original the !matched only hits on the first run (so it can be done before the loop) and the comma also hits only there. so both parts can be done before the loop