### PR TITLE
Selector: Add :invalid and :valid selectors

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -1524,6 +1524,15 @@ Expr = Sizzle.selectors = {
 			return elem.selected === true;
 		},
 
+		"invalid": function( elem ) {
+			// Both `invaild` and `valid` return false if elem has no `validity` attribute
+			return elem.validity !== undefined && elem.validity.valid === false;
+		},
+
+		"valid": function( elem ) {
+			return elem.validity !== undefined && elem.validity.valid === true;
+		},
+
 		// Contents
 		"empty": function( elem ) {
 			// http://www.w3.org/TR/selectors/#empty-pseudo


### PR DESCRIPTION
Add :invalid and :valid pseudoclass selectors.

The implementation is based on element's [validity attribute](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState).

If element has no `validity` attribute, it's supposed, that both functions return false. This also matches CSS behaviour.