### PR TITLE
Fix for IE iframe 'permission denied' errors

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -221,6 +221,14 @@ function Sizzle( selector, context, results, seed ) {
 
 	results = results || [];
 
+	 // Balasaheb - this try/catch seems to fix IE 'permission denied' errors as described here:
+         try {
+               document === document; //may cause permission denied
+            }
+        catch (err) {
+                document = window.document; //resets document, and no more permission denied errors.
+           }
+	
 	// Return early from calls with invalid selector or context
 	if ( typeof selector !== "string" || !selector ||
 		nodeType !== 1 && nodeType !== 9 && nodeType !== 11 ) {


### PR DESCRIPTION
This is the fix for iframe when selector is used for the elements within iframe then next time when jquery selector is used for parent window then "Permission denied" error comes in IE.