### PR TITLE
Selector: fix nonnativeSelectorCache

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -331,7 +331,7 @@ function Sizzle( selector, context, results, seed ) {
 						);
 						return results;
 					} catch ( qsaError ) {
-						nonnativeSelectorCache( selector );
+						nonnativeSelectorCache( selector, true );
 					} finally {
 						if ( nid === expando ) {
 							context.removeAttribute( "id" );
@@ -997,7 +997,7 @@ Sizzle.matchesSelector = function( elem, expr ) {
 				return ret;
 			}
 		} catch (e) {
-			nonnativeSelectorCache( expr );
+			nonnativeSelectorCache( expr, true );
 		}
 	}
 


### PR DESCRIPTION
The [change](https://github.com/jquery/sizzle/pull/396) that has fixed #393 introduced another bug. 

The problem is that the `!nonnativeSelectorCache[ expr + " " ]` check always returns `true` even if the cache contains the specified key.