### PR TITLE
Selector: avoid calls to setAttribute( "id" ) by examining selector

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -132,6 +132,8 @@ var i,
 
 	rsibling = /[+~]/,
 
+	rcomplex = new RegExp(whitespace + "|>"),
+
 	// CSS escapes
 	// http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
 	runescape = new RegExp( "\\\\([\\da-f]{1,6}" + whitespace + "?|(" + whitespace + ")|.)", "ig" ),
@@ -304,20 +306,26 @@ function Sizzle( selector, context, results, seed ) {
 				// Exclude object elements
 				} else if ( context.nodeName.toLowerCase() !== "object" ) {
 
-					// Capture the context ID, setting it first if necessary
-					if ( (nid = context.getAttribute( "id" )) ) {
-						nid = nid.replace( rcssescape, fcssescape );
+					// The workaround is only necessary if the selector
+					// contains child or descendant combinators.
+					if ( !rcomplex.test( selector ) ) {
+						newSelector = selector;
 					} else {
-						context.setAttribute( "id", (nid = expando) );
-					}
+						// Capture the context ID, setting it first if necessary
+						if ( (nid = context.getAttribute( "id" )) ) {
+							nid = nid.replace( rcssescape, fcssescape );
+						} else {
+							context.setAttribute( "id", (nid = expando) );
+						}
 
-					// Prefix every selector in the list
-					groups = tokenize( selector );
-					i = groups.length;
-					while ( i-- ) {
-						groups[i] = "#" + nid + " " + toSelector( groups[i] );
+						// Prefix every selector in the list
+						groups = tokenize( selector );
+						i = groups.length;
+						while ( i-- ) {
+							groups[i] = "#" + nid + " " + toSelector( groups[i] );
+						}
+						newSelector = groups.join( "," );
 					}
-					newSelector = groups.join( "," );
 
 					// Expand context for sibling selectors
 					newContext = rsibling.test( selector ) && testContext( context.parentNode ) ||


### PR DESCRIPTION
Additionally, use :scope when available.

This implements the optimization proposed in [issue 430](https://github.com/jquery/sizzle/issues/430).  I modified the official benchmark to use `document.documentElement` so the relevant code path would be reached, and it has shown a modest but consistent improvement in every browser I've tested.  It can be found [here](https://wartmanm.github.io/sizzle/speed/?qsa).

In practice, I've seen this change more than halve the load times of some pages in Edge, which seems to have particularly slow `setAttribute` calls.

I don't know if this is the best possible order in which to try alternatives, but it is the best I could come up with.  Using the selector verbatim when possible appears to be the fastest across browsers by a small margin.  I haven't been able to find a clear winner between `:scope` and `getAttribute("id")`.  `:scope` is probably not able to be shared with CSS or with other qSA calls, but `#id` should be, and my hope is that this advantage outweighs the cost of calling `getAttribute`.