### PR TITLE
Core: Throws an error if the document element is null

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -579,10 +579,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		doc = node ? node.ownerDocument || node : preferredDoc;
 
 	// Return early if doc is invalid or already selected
-	if ( doc === document || doc.nodeType !== 9 || !doc.documentElement ) {
-		if ( !document ) {
-			throw new Error( "Sizzle requires the document element" );
-		}
+	if ( doc === document || doc.nodeType !== 9 ) {
 		return document;
 	}
 

--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -580,6 +580,9 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 	// Return early if doc is invalid or already selected
 	if ( doc === document || doc.nodeType !== 9 || !doc.documentElement ) {
+		if ( !document ) {
+			throw new Error( "Sizzle requires the document element" );
+		}
 		return document;
 	}
 


### PR DESCRIPTION
If Sizzle/jQuery is injected to a page before the document element is constructed (`window.document.documentElement === null`), it fails to initialize. I would like to reference [jquery/jquery#3333](https://github.com/jquery/jquery/issues/3333) to describe the issue.

`setDocument()` however simply returns `document` in such case -- even if the variable `document` hasn't been assigned yet (when Sizzle is initializing).

> Sizzle initializes against the default document https://github.com/jquery/sizzle/blob/67e9691e8689b824387affb9da06dc663da63598/src/sizzle.js#L2208

> `setDocument()` checks for `doc.documentElement` https://github.com/jquery/sizzle/blob/67e9691e8689b824387affb9da06dc663da63598/src/sizzle.js#L582

It later produces an error `TypeError: "document is undefined"` in `assert()` though the problem was actually there when `setDocument()` silently returned. This makes it harder for a dev-user to know what's just happened as `window.document ` exists but `window.document.documentElement` doesn't. This pull request is intended to make the error verbose.