### PR TITLE
document.documentElement can be null in Safari

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -859,7 +859,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			var adown = a.nodeType === 9 ? a.documentElement : a,
 				bup = b && b.parentNode;
 			return a === bup || !!( bup && bup.nodeType === 1 && (
-				adown.contains ?
+				adown && adown.contains ?
 					adown.contains( bup ) :
 					a.compareDocumentPosition && a.compareDocumentPosition( bup ) & 16
 			));


### PR DESCRIPTION
I am not quite sure when it can be null, but I've observed this in our application. It happens only in Safari 12 and might be related to iframes. I am not sure if this is a good fix, but does not seem like a bad idea to protect against this case if there is a real world case suggesting document.documentElement can be null.