### PR TITLE
Core: Throw a better error when documentElement is missing

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -602,7 +602,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		doc = node ? node.ownerDocument || node : preferredDoc;
 
 	// Return early if doc is invalid or already selected
-	if ( doc === document || doc.nodeType !== 9 || !doc.documentElement ) {
+	if ( doc === document || doc.nodeType !== 9 ) {
 		return document;
 	}
 


### PR DESCRIPTION
This is a resubmit of gh-439 that was lost during the switch from JSHint + JSCS
to ESLint

Ref gh-442
Ref gh-439

(cherry picked from commit 7d92424c1a65a367a45034803e9de97462ea42e5)