### PR TITLE
Build: Run Karma tests sequentially in separate processes + other improvements

### DIFF
--- a/.eslintrc-node.json
+++ b/.eslintrc-node.json
@@ -4,7 +4,7 @@
 	"extends": "jquery",
 
 	"parserOptions": {
-		"ecmaVersion": 2017
+		"ecmaVersion": 2018
 	},
 
 	"env": {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,19 +258,9 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "lint", [ "jsonlint", "eslint:dev", "eslint:dist" ] );
 	grunt.registerTask( "start", [ "karma:watch:start", "watch" ] );
 
-	// Execute tests all browsers in sequential way,
-	// so slow connections would not affect other runs
-	grunt.registerTask( "tests", isBrowserStack ? [
-		"karma:phantom", "karma:desktop",
-
-		"karma:ios",
-
-		"karma:oldIe", "karma:oldFirefox", "karma:oldChrome",
-		"karma:oldSafari", "karma:oldOpera"
-
-		// See #314 :-(
-		// "karma:android", "karma:oldAndroid"
-	] : "karma:phantom" );
+	grunt.registerTask( "tests", [
+		`karma-tests:${ isBrowserStack ? "browserstack" : "" }`
+	] );
 
 	grunt.registerTask( "build", [
 		"jsonlint",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,16 +32,16 @@ module.exports = function( grunt ) {
 
 		browsers.desktop = [
 			"bs_chrome-45", // shares V8 with Node.js 4 LTS
-			"bs_chrome-70", "bs_chrome-71",
+			"bs_chrome-75", "bs_chrome-76",
 
 			"bs_firefox-52", "bs_firefox-60", // Firefox ESR
-			"bs_firefox-63", "bs_firefox-64",
+			"bs_firefox-67", "bs_firefox-68",
 
 			"bs_edge-17", "bs_edge-18",
 
 			"bs_ie-9", "bs_ie-10", "bs_ie-11",
 
-			"bs_opera-56", "bs_opera-57",
+			"bs_opera-60", "bs_opera-62",
 
 			// Real Safari 6.1 and 7.0 are not available
 			"bs_safari-6.0", "bs_safari-8.0", "bs_safari-9.1", "bs_safari-10.1",

--- a/tasks/karma-tests.js
+++ b/tasks/karma-tests.js
@@ -21,7 +21,7 @@ module.exports = function( grunt ) {
 
 			// See #314 :-(
 			// "karma:android", "karma:oldAndroid"
-		] : "karma:phantom";
+		] : [ "karma:phantom" ];
 
 		for ( let task of tasks ) {
 			const command = `grunt ${ task }`;

--- a/tasks/karma-tests.js
+++ b/tasks/karma-tests.js
@@ -9,43 +9,44 @@ module.exports = function( grunt ) {
 	// sets to somehow still be waited on during subsequent runs, failing the build.
 	grunt.registerTask( "karma-tests", "Run unit tests sequentially",
 		async function( isBrowserStack ) {
-		const done = this.async();
+			const done = this.async();
 
-		const tasks = isBrowserStack ? [
-			"karma:phantom", "karma:desktop",
+			const tasks = isBrowserStack ? [
+				"karma:phantom", "karma:desktop",
 
-			"karma:oldIe", "karma:oldFirefox", "karma:oldChrome",
-			"karma:oldSafari", "karma:oldOpera",
+				"karma:oldIe", "karma:oldFirefox", "karma:oldChrome",
+				"karma:oldSafari", "karma:oldOpera",
 
-			"karma:ios"
+				"karma:ios"
 
-			// See #314 :-(
-			// "karma:android", "karma:oldAndroid"
-		] : [ "karma:phantom" ];
+				// See #314 :-(
+				// "karma:android", "karma:oldAndroid"
+			] : [ "karma:phantom" ];
 
-		for ( let task of tasks ) {
-			const command = `grunt ${ task }`;
-			grunt.log.writeln( `Running task ${ task } in a subprocess...` );
+			for ( let task of tasks ) {
+				const command = `grunt ${ task }`;
+				grunt.log.writeln( `Running task ${ task } in a subprocess...` );
 
-			await new Promise( ( resolve, reject ) => {
-				const ret = spawn( command, {
-					shell: true,
-					stdio: "inherit"
+				await new Promise( ( resolve, reject ) => {
+					const ret = spawn( command, {
+						shell: true,
+						stdio: "inherit"
+					} );
+
+					ret.on( "close", ( code ) => {
+						if ( code === 0 ) {
+							resolve();
+						} else {
+							const message = `Error code ${ code } during command: ${ command }`;
+							console.error( message );
+							reject( new Error( message ) );
+							done( false );
+						}
+					} );
 				} );
+			}
 
-				ret.on( "close", ( code ) => {
-					if ( code === 0 ) {
-						resolve();
-					} else {
-						const message = `Error code ${ code } during command: ${ command }`;
-						console.error( message );
-						reject( new Error( message ) );
-						done( false );
-					}
-				} );
-			} );
+			done();
 		}
-
-		done();
-	} );
+	);
 };

--- a/tasks/karma-tests.js
+++ b/tasks/karma-tests.js
@@ -14,10 +14,10 @@ module.exports = function( grunt ) {
 		const tasks = isBrowserStack ? [
 			"karma:phantom", "karma:desktop",
 
-			"karma:ios",
-
 			"karma:oldIe", "karma:oldFirefox", "karma:oldChrome",
-			"karma:oldSafari", "karma:oldOpera"
+			"karma:oldSafari", "karma:oldOpera",
+
+			"karma:ios"
 
 			// See #314 :-(
 			// "karma:android", "karma:oldAndroid"

--- a/test/karma/launchers.js
+++ b/test/karma/launchers.js
@@ -251,7 +251,8 @@ module.exports = {
 		base: "BrowserStack",
 		device: "iPhone 7",
 		os: "ios",
-		os_version: "10.3"
+		os_version: "10.3",
+		real_mobile: true
 	},
 	"bs_ios-11.4": {
 		base: "BrowserStack",

--- a/test/karma/launchers.js
+++ b/test/karma/launchers.js
@@ -22,17 +22,17 @@ module.exports = {
 		os: "OS X",
 		os_version: "High Sierra"
 	},
-	"bs_firefox-63": {
+	"bs_firefox-67": {
 		base: "BrowserStack",
 		browser: "firefox",
-		browser_version: "63.0",
+		browser_version: "67.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
-	"bs_firefox-64": {
+	"bs_firefox-68": {
 		base: "BrowserStack",
 		browser: "firefox",
-		browser_version: "64.0",
+		browser_version: "68.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
@@ -51,17 +51,17 @@ module.exports = {
 		os: "OS X",
 		os_version: "Sierra"
 	},
-	"bs_chrome-70": {
+	"bs_chrome-75": {
 		base: "BrowserStack",
 		browser: "chrome",
-		browser_version: "70.0",
+		browser_version: "75.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
-	"bs_chrome-71": {
+	"bs_chrome-76": {
 		base: "BrowserStack",
 		browser: "chrome",
-		browser_version: "71.0",
+		browser_version: "76.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
@@ -138,17 +138,17 @@ module.exports = {
 		os: "Windows",
 		os_version: "7"
 	},
-	"bs_opera-56": {
+	"bs_opera-60": {
 		base: "BrowserStack",
 		browser: "opera",
-		browser_version: "56.0",
+		browser_version: "60.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
-	"bs_opera-57": {
+	"bs_opera-62": {
 		base: "BrowserStack",
 		browser: "opera",
-		browser_version: "57.0",
+		browser_version: "62.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},


### PR DESCRIPTION
Sizzle hasn't been able to finish all its unit tests successfully for a long time. This PR attempts to make it work again (at least most of the time).

1. A new "karma-tests" task is created; it runs tests in various browser sets
but does it sequentially in separate processes to avoid Karma bugs that cause
browsers from previous sets to somehow still be waited on during subsequent
runs, failing the build.
1. Upgrade tested browsers
1. Run iOS tests at the end (as it fails more often than other browsers)
1. Use real iOS 10.3 device in Karma

We can't upgrade Karma as the latest version (`4.2.0`) hangs in IE 7 (IE 8 seems to work fine there).

~~Note: it's expected that tests fail on this PR when merged due to #454. I temporarily disabled `oldFirefox` tests & pushed it to origin to see if it will succeed other than that and it did: https://travis-ci.org/jquery/sizzle/builds/574066624~~ EDIT: That issue is fixed now.