### PR TITLE
Selector: Detect incorrect escape handling by old Firefox

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -846,6 +846,12 @@ setDocument = Sizzle.setDocument = function( node ) {
 				rbuggyQSA.push( ":enabled", ":disabled" );
 			}
 
+			// Support: Firefox <=3.6 - 5 only
+			// Old Firefox doesn't throw on a badly-escaped identifier.
+			el.querySelectorAll( "\\\f" );
+			rbuggyQSA.push( "[\\r\\n\\f]" );
+
+			// Support: Opera 10 - 11 only
 			// Opera 10-11 does not throw on post-comma invalid pseudos
 			el.querySelectorAll( "*,:x" );
 			rbuggyQSA.push( ",.*:" );


### PR DESCRIPTION
According to:
https://www.w3.org/TR/css-syntax-3/#ident-token-diagram
the escape doesn't need to be followed by a whitespace only if it's not a hex
digit or a newline. However, old Firefox (3.6 - 5 only) doesn't throw if an
escaped newline is not followed by a space. Fallback to Sizzle in such cases.

Fixes gh-454