### PR TITLE
Build: Update tested browsers, test on Edge 15-18 instead of just 17-18

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,24 +32,24 @@ module.exports = function( grunt ) {
 
 		browsers.desktop = [
 			"bs_chrome-45", // shares V8 with Node.js 4 LTS
-			"bs_chrome-75", "bs_chrome-76",
+			"bs_chrome-76", "bs_chrome-77",
 
 			"bs_firefox-52", "bs_firefox-60", // Firefox ESR
-			"bs_firefox-67", "bs_firefox-68",
+			"bs_firefox-68", "bs_firefox-69",
 
-			"bs_edge-17", "bs_edge-18",
+			"bs_edge-15", "bs_edge-16", "bs_edge-17", "bs_edge-18",
 
 			"bs_ie-9", "bs_ie-10", "bs_ie-11",
 
-			"bs_opera-60", "bs_opera-62",
+			"bs_opera-63", "bs_opera-64",
 
 			// Real Safari 6.1 and 7.0 are not available
 			"bs_safari-6.0", "bs_safari-8.0", "bs_safari-9.1", "bs_safari-10.1",
-			"bs_safari-11.1", "bs_safari-12.0"
+			"bs_safari-11.1", "bs_safari-12.1"
 		];
 
 		browsers.ios = [
-			"bs_ios-9.3", "bs_ios-10.3", "bs_ios-11.4", "bs_ios-12.1"
+			"bs_ios-9.3", "bs_ios-10.3", "bs_ios-11.4", "bs_ios-12.2"
 		];
 		browsers.android = [
 			"bs_android-4.0", "bs_android-4.1", "bs_android-4.2",

--- a/test/karma/launchers.js
+++ b/test/karma/launchers.js
@@ -22,17 +22,17 @@ module.exports = {
 		os: "OS X",
 		os_version: "High Sierra"
 	},
-	"bs_firefox-67": {
-		base: "BrowserStack",
-		browser: "firefox",
-		browser_version: "67.0",
-		os: "OS X",
-		os_version: "Mojave"
-	},
 	"bs_firefox-68": {
 		base: "BrowserStack",
 		browser: "firefox",
 		browser_version: "68.0",
+		os: "OS X",
+		os_version: "Mojave"
+	},
+	"bs_firefox-69": {
+		base: "BrowserStack",
+		browser: "firefox",
+		browser_version: "69.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
@@ -51,13 +51,6 @@ module.exports = {
 		os: "OS X",
 		os_version: "Sierra"
 	},
-	"bs_chrome-75": {
-		base: "BrowserStack",
-		browser: "chrome",
-		browser_version: "75.0",
-		os: "OS X",
-		os_version: "Mojave"
-	},
 	"bs_chrome-76": {
 		base: "BrowserStack",
 		browser: "chrome",
@@ -65,7 +58,28 @@ module.exports = {
 		os: "OS X",
 		os_version: "Mojave"
 	},
+	"bs_chrome-77": {
+		base: "BrowserStack",
+		browser: "chrome",
+		browser_version: "77.0",
+		os: "OS X",
+		os_version: "Mojave"
+	},
 
+	"bs_edge-15": {
+		base: "BrowserStack",
+		browser: "edge",
+		browser_version: "15.0",
+		os: "Windows",
+		os_version: "10"
+	},
+	"bs_edge-16": {
+		base: "BrowserStack",
+		browser: "edge",
+		browser_version: "16.0",
+		os: "Windows",
+		os_version: "10"
+	},
 	"bs_edge-17": {
 		base: "BrowserStack",
 		browser: "edge",
@@ -138,17 +152,17 @@ module.exports = {
 		os: "Windows",
 		os_version: "7"
 	},
-	"bs_opera-60": {
+	"bs_opera-63": {
 		base: "BrowserStack",
 		browser: "opera",
-		browser_version: "60.0",
+		browser_version: "63.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
-	"bs_opera-62": {
+	"bs_opera-64": {
 		base: "BrowserStack",
 		browser: "opera",
-		browser_version: "62.0",
+		browser_version: "64.0",
 		os: "OS X",
 		os_version: "Mojave"
 	},
@@ -209,10 +223,10 @@ module.exports = {
 		os: "OS X",
 		os_version: "High Sierra"
 	},
-	"bs_safari-12.0": {
+	"bs_safari-12.1": {
 		base: "BrowserStack",
 		browser: "safari",
-		browser_version: "12.0",
+		browser_version: "12.1",
 		os: "OS X",
 		os_version: "Mojave"
 	},
@@ -261,11 +275,11 @@ module.exports = {
 		os_version: "11.4",
 		real_mobile: true
 	},
-	"bs_ios-12.1": {
+	"bs_ios-12.2": {
 		base: "BrowserStack",
 		device: "iPhone XS",
 		os: "ios",
-		os_version: "12.1",
+		os_version: "12.2",
 		real_mobile: true
 	},
 


### PR DESCRIPTION
Sizzle supports all versions of Edge (see https://github.com/jquery/sizzle/wiki#-browser-support), so 12+. We only tested v17 & v18 so far while BrowserStack makes all version starting from 15 available. We should test in them all as sometimes it catches a new issue (see https://github.com/jquery/sizzle/pull/461#issuecomment-541871745). Plus, new EdgeHTML-based versions of Edge are unlikely so this list won't get much bigger.