### PR TITLE
Tests: Test for Shadow DOM v1 support

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1551,16 +1551,12 @@ QUnit.test( "select() with pre-compiled function", function( assert ) {
 	} );
 } );
 
-QUnit.test( "Sizzle supports shadow DOM nodes as root", function( assert ) {
-	if ( !document.documentElement.createShadowRoot ) {
-		assert.ok( true, "Shadow DOM not supported in this browser" );
-		return;
-	}
-
+QUnit[ document.body.attachShadow && document.body.getRootNode ? "test" : "skip" ](
+	"Sizzle supports shadow DOM nodes as root", function( assert ) {
 	assert.expect( 2 );
 
-	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" )[ 0 ],
-		shadowRoot = div.createShadowRoot();
+	var shadowHost = jQuery( "<div/>" ).appendTo( "#qunit-fixture" )[ 0 ],
+		shadowRoot = shadowHost.attachShadow( { mode: "open" } );
 
 	shadowRoot.innerHTML = "<div class='vagabond'><p></p></div>";
 	assert.equal( Sizzle( ".vagabond", shadowRoot ).length, 1,


### PR DESCRIPTION
There was a test for Shadow DOM nodes working as root but it was using Shadow
DOM v0 that only Chromium implements and which it plans to remove in the future.
The test was reworked to rely on Shadow DOM v1.

jQuery master already uses the new API in its tests.