### PR TITLE
Build: Remove the version field from the bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,5 @@
     "CSS",
     "selector",
     "jquery"
-  ],
-  "version": "2.3.4"
+  ]
 }


### PR DESCRIPTION
jquery-release only updates the version in the tag so it stays stale on master
(e.g. now it has `2.3.4` when `2.3.5` has already been released). Instead,
just remove the version from there.

I tested this with jquery-release and it still correctly adds the version field.