### PR TITLE
Core: Make Sizzle.isXML accept falsy input

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -589,8 +589,8 @@ support = Sizzle.support = {};
  * @returns {Boolean} True iff elem is a non-HTML XML node
  */
 isXML = Sizzle.isXML = function( elem ) {
-	var namespace = elem.namespaceURI,
-		docElem = ( elem.ownerDocument || elem ).documentElement;
+	var namespace = elem && elem.namespaceURI,
+		docElem = elem && ( elem.ownerDocument || elem ).documentElement;
 
 	// Support: IE <=8
 	// Assume HTML when documentElement doesn't yet exist, such as inside loading iframes

--- a/test/unit/utilities.js
+++ b/test/unit/utilities.js
@@ -197,7 +197,7 @@ if ( jQuery( "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='1' w
 }
 
 QUnit.test( "Sizzle.isXML", function( assert ) {
-	assert.expect( 10 );
+	assert.expect( 15 );
 
 	var svgTree,
 		xmlTree = jQuery.parseXML( "<docElem><elem/></docElem>" ).documentElement,
@@ -255,6 +255,12 @@ QUnit.test( "Sizzle.isXML", function( assert ) {
 	} else {
 		assert.ok( true, "Cannot test an incomplete DOM" );
 	}
+
+	assert.strictEqual( jQuery.isXMLDoc( undefined ), false, "undefined" );
+	assert.strictEqual( jQuery.isXMLDoc( null ), false, "null" );
+	assert.strictEqual( jQuery.isXMLDoc( false ), false, "false" );
+	assert.strictEqual( jQuery.isXMLDoc( 0 ), false, "0" );
+	assert.strictEqual( jQuery.isXMLDoc( "" ), false, "\"\"" );
 } );
 
 QUnit.test( "Sizzle.uniqueSort", function( assert ) {


### PR DESCRIPTION
Fixes jquery/jquery#4782
Ref jquery/jquery#4814

jQuery version for jQuery 4.0: https://github.com/jquery/jquery/pull/4814.