### PR TITLE
Core: Make Sizzle.contains work within <template/> elements

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -987,7 +987,14 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// As in, an element does not contain itself
 	contains = hasCompare || rnative.test( docElem.contains ) ?
 		function( a, b ) {
-			var adown = a.nodeType === 9 ? a.documentElement : a,
+
+			// Support: IE <9 only
+			// IE doesn't have `contains` on `document` so we need to check for
+			// `documentElement` presence.
+			// We need to fall back to `a` when `documentElement` is missing
+			// as `ownerDocument` of elements within `<template/>` may have
+			// a null one - a default behavior of all modern browsers.
+			var adown = a.nodeType === 9 && a.documentElement || a,
 				bup = b && b.parentNode;
 			return a === bup || !!( bup && bup.nodeType === 1 && (
 				adown.contains ?

--- a/test/unit/utilities.js
+++ b/test/unit/utilities.js
@@ -176,6 +176,25 @@ QUnit.test( "Sizzle.contains", function( assert ) {
 	assert.ok( !Sizzle.contains( document, detached ), "document container (negative)" );
 } );
 
+// Support: IE 6 - 11+, Edge <13 only, Firefox <23 only, Chrome <27 only
+// Run this test only in browsers supporting `HTMLTemplateElement`.
+QUnit[
+	typeof HTMLTemplateElement === "function" ?
+		"test" :
+		"skip"
+]( "jQuery.contains within <template/> doesn't throw (gh-5147)", function( assert ) {
+	assert.expect( 1 );
+
+	var template = jQuery( "<template><div><div class='a'></div></div></template>" ),
+		a = template[ 0 ].content.querySelector( ".a" );
+
+	template.appendTo( "#qunit-fixture" );
+
+	Sizzle.contains( a.ownerDocument, a );
+
+	assert.ok( true, "Didn't throw" );
+} );
+
 if ( jQuery( "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='1' width='1'><g/></svg>"
 	)[ 0 ].firstChild ) {
 


### PR DESCRIPTION
The `<template/>` element `contents` property is a document fragment that may have a `null` `documentElement`. In Safari 16 this happens in more cases due to recent spec changes - in particular, even if that document fragment is explicitly adopted into an outer document. We're testing both of those cases now.

The above behavior made `Sizzle.contains` crash when run on certain elements within the `<template/>` element. As it turns out, we don't need to query the supposed container `documentElement` if it has the `Node.DOCUMENT_NODE` (9) `nodeType`; we can call `.contains()` directly on the `document`. That avoids the crash.

However, we still need to fall back to `documentElement` if one is defined as IE <9 have a broken `.contains()` on the document.

Fixes jquery/jquery#5147
Ref jquery/jquery#5158

I run tests on all browsers locally and they passed.

This is one of the jQuery 3.6.2 blockers.