### PR TITLE
Selector: Make selector lists work with `qSA` again

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -367,7 +367,7 @@ function Sizzle( selector, context, results, seed ) {
 					if ( support.cssSupportsSelector &&
 
 						// eslint-disable-next-line no-undef
-						!CSS.supports( "selector(" + newSelector + ")" ) ) {
+						!CSS.supports( "selector(:is(" + newSelector + "))" ) ) {
 
 						// Support: IE 11+
 						// Throw to get to the same code path as an error directly in qSA.
@@ -969,9 +969,9 @@ setDocument = Sizzle.setDocument = function( node ) {
 		// `:has()` uses a forgiving selector list as an argument so our regular
 		// `try-catch` mechanism fails to catch `:has()` with arguments not supported
 		// natively like `:has(:contains("Foo"))`. Where supported & spec-compliant,
-		// we now use `CSS.supports("selector(SELECTOR_TO_BE_TESTED)")` but outside
-		// that, let's mark `:has` as buggy to always use jQuery traversal for
-		// `:has()`.
+		// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")` but,
+		// outside that, let's mark `:has` as buggy to always use jQuery traversal
+		// for `:has()`.
 		rbuggyQSA.push( ":has" );
 	}
 

--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -969,9 +969,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 		// `:has()` uses a forgiving selector list as an argument so our regular
 		// `try-catch` mechanism fails to catch `:has()` with arguments not supported
 		// natively like `:has(:contains("Foo"))`. Where supported & spec-compliant,
-		// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")` but,
-		// outside that, let's mark `:has` as buggy to always use jQuery traversal
-		// for `:has()`.
+		// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")`, but
+		// outside that we mark `:has` as buggy.
 		rbuggyQSA.push( ":has" );
 	}
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -371,6 +371,37 @@ QUnit.test( "multiple", function( assert ) {
 		[ "h2", "firstp", "ap", "sndp", "en", "sap", "first" ] );
 } );
 
+( function() {
+	var supportsValidPseudo;
+	try {
+		supportsValidPseudo = document.querySelectorAll( "input:valid" ) &&
+
+			// Support: Firefox 3.6 only
+			// Firefox 3.6 doesn't support the `:valid` pseudo-class, but it also
+			// doesn't throw when a `qSA` call includes it.
+			!/firefox\/3\.6/i.test( navigator.userAgent );
+	} catch ( e ) {
+		supportsValidPseudo = false;
+	}
+
+	if ( supportsValidPseudo ) {
+		QUnit.test( "multiple, only supported natively (jquery/jquery#5177)", function( assert ) {
+			assert.expect( 4 );
+
+			jQuery( "#qunit-fixture" ).prepend( "<h2 id='h2'/>" );
+
+			t( "Comma Support", "#qunit-fixture #search:valid, #qunit-fixture p",
+				[ "firstp", "ap", "sndp", "en", "sap", "first", "search" ] );
+			t( "Comma Support", "#qunit-fixture #search:valid , #qunit-fixture p",
+				[ "firstp", "ap", "sndp", "en", "sap", "first", "search" ] );
+			t( "Comma Support", "#qunit-fixture #search:valid,#qunit-fixture p",
+				[ "firstp", "ap", "sndp", "en", "sap", "first", "search" ] );
+			t( "Comma Support", "#qunit-fixture #search:valid\t,\r#qunit-fixture p\n",
+				[ "firstp", "ap", "sndp", "en", "sap", "first", "search" ] );
+		} );
+	}
+} )();
+
 QUnit.test( "child and adjacent", function( assert ) {
 	assert.expect( 43 );
 


### PR DESCRIPTION
Sizzle 2.3.7 started using `CSS.supports( "selector(SELECTOR)" )` before using `querySelectorAll` on the selector. This was to solve jquery/jquery#5098 - some selectors, like `:has()`, now had their parameters parsed in a forgiving way, meaning that `:has(:fakepseudo)` no longer throws but just returns 0 results, breaking that Sizzle mechanism.

A recent spec change made `CSS.supports( "selector(SELECTOR)" )` always use non-forgiving parsing, allowing us to use this API for what we've used `try-catch` before.

To solve the issue on the spec side for older jQuery versions, `:has()` parameters are no longer using forgiving parsing in the latest spec update but our new mechanism is more future-proof anyway.

However, the Sizzle implementation has a bug - in
`CSS.supports( "selector(SELECTOR)" )`, `SELECTOR` needs to be a `<complex-selector>` and not a `<complex-selector-list>`. Which means that selector lists now skip `qSA` and go to the Sizzle custom traversal:
```js
CSS.supports("selector(div:valid, span)"); // false
CSS.supports("selector(div:valid)"); // true
CSS.supports("selector(span)"); // true
```

To solve this, this commit wraps the selector list passed to `CSS.supports( "selector(:is(SELECTOR))" )` with `:is`, making it a single selector again.

See:
* https://w3c.github.io/csswg-drafts/css-conditional-4/#at-supports-ext
* https://w3c.github.io/csswg-drafts/selectors-4/#typedef-complex-selector
* https://w3c.github.io/csswg-drafts/selectors-4/#typedef-complex-selector-list

Fixes jquery/jquery#5177
Ref w3c/csswg-drafts#7280

+2 bytes