### PR TITLE
fix(sec): upgrade jquery to 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "grunt-karma": "2.0.0",
         "grunt-npmcopy": "0.1.0",
         "gzip-js": "0.3.2",
-        "jquery": "1.9.1",
+        "jquery": "3.5.0",
         "karma": "1.3.0",
         "karma-browserstack-launcher": "1.3.0",
         "karma-chrome-launcher": "2.2.0",
@@ -4630,9 +4630,9 @@
       "dev": true
     },
     "node_modules/jquery": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
-      "integrity": "sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -12256,9 +12256,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
-      "integrity": "sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "grunt-karma": "2.0.0",
     "grunt-npmcopy": "0.1.0",
     "gzip-js": "0.3.2",
-    "jquery": "1.9.1",
+    "jquery": "3.5.0",
     "karma": "1.3.0",
     "karma-browserstack-launcher": "1.3.0",
     "karma-chrome-launcher": "2.2.0",


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in jquery 1.9.1
- [CVE-2020-11022](https://www.oscs1024.com/hd/CVE-2020-11022)


### What did I do？
Upgrade jquery from 1.9.1 to 3.5.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS