### PR TITLE
Docs: Archive Sizzle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function( grunt ) {
 	// if Browserstack is set up, assume we can use it
 	if ( isBrowserStack ) {
 
-		// See https://github.com/jquery/sizzle/wiki/Sizzle-Documentation#browsers
+		// See https://github.com/jquery-archive/sizzle/wiki/Sizzle-Documentation#browsers
 
 		browsers.desktop = [
 			"bs_chrome-124", // shares V8 with Node.js v22.21.1 LTS

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ Copyright JS Foundation and other contributors, https://js.foundation/
 
 This software consists of voluntary contributions made by many
 individuals. For exact contribution history, see the revision history
-available at https://github.com/jquery/sizzle
+available at https://github.com/jquery-archive/sizzle
 
 The following license applies to all parts of this software except as
 documented below:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 __A pure-JavaScript CSS selector engine designed to be easily dropped in to a host library.__
 
 - [More information](https://sizzlejs.com/)
-- [Documentation](https://github.com/jquery/sizzle/wiki/)
-- [Browser support](https://github.com/jquery/sizzle/wiki/#wiki-browsers)
+- [Documentation](https://github.com/jquery-archive/sizzle/wiki/)
+- [Browser support](https://github.com/jquery-archive/sizzle/wiki/#wiki-browsers)
 
 Contribution Guides
 ---------------------------
@@ -35,7 +35,7 @@ How to build Sizzle
 Clone a copy of the main Sizzle git repo by running:
 
 ```bash
-git clone git@github.com:jquery/sizzle.git
+git clone git@github.com:jquery-archive/sizzle.git
 ```
 
 In the `sizzle/dist` folder you will find build version of sizzle along with the minified copy and associated map file.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Sizzle
 
+--------------------
+
+**NOTE: Sizzle is no longer maintained. jQuery versions `3.7.0` or newer no longer depend on Sizzle. Issues with the jQuery selector engine should be reported directly to jQuery at https://github.com/jquery/jquery/issues.**
+
+--------------------
+
 __A pure-JavaScript CSS selector engine designed to be easily dropped in to a host library.__
 
 - [More information](https://sizzlejs.com/)

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "homepage": "https://sizzlejs.com",
   "author": {
     "name": "JS Foundation and other contributors",
-    "url": "https://github.com/jquery/sizzle/blob/main/AUTHORS.txt"
+    "url": "https://github.com/jquery-archive/sizzle/blob/main/AUTHORS.txt"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jquery/sizzle.git"
+    "url": "https://github.com/jquery-archive/sizzle.git"
   },
   "bugs": {
-    "url": "https://github.com/jquery/sizzle/issues"
+    "url": "https://github.com/jquery-archive/sizzle/issues"
   },
   "license": "MIT",
   "files": [

--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -1221,7 +1221,7 @@ Sizzle.uniqueSort = function( results ) {
 	}
 
 	// Clear input after sorting to release objects
-	// See https://github.com/jquery/sizzle/pull/225
+	// See https://github.com/jquery-archive/sizzle/pull/225
 	sortInput = null;
 
 	return results;


### PR DESCRIPTION
Steps to archive Sizzle (steps 1-2 are covered by this PR):

1. Rename GitHub references from jquery/sizzle to jquery-archive/sizzle.
2. Add a deprecation notice to the README.
3. Release a new patch update.
4. Deprecate on npm.
5. Write a blog post about archiving Sizzle.
